### PR TITLE
AdChoices Android support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fbads",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "Native Facebook Ads for React Native",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fbads",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Native Facebook Ads for React Native",
   "repository": {
     "type": "git",

--- a/src/AdChoices.js
+++ b/src/AdChoices.js
@@ -6,7 +6,7 @@ var cfg = {
         shouldNotifyLoadEvents: true
     },
     propTypes: {
-        nativeAdView: PropTypes.number,
+        // nativeAdView: PropTypes.number,
         ...View.propTypes
     }
 };

--- a/src/AdChoices.js
+++ b/src/AdChoices.js
@@ -1,0 +1,21 @@
+import React, { Component, PropTypes } from 'react';
+import { View, requireNativeComponent } from 'react-native';
+
+var cfg = {
+    nativeOnly: {
+        shouldNotifyLoadEvents: true
+    },
+    propTypes: {
+        nativeAdView: PropTypes.number,
+        ...View.propTypes
+    }
+};
+
+const AdChoices = requireNativeComponent('CTKAdChoice', null);
+
+
+const AdChoicesComponent = props => {
+    return <AdChoices {...props} />;
+}
+
+export default AdChoicesComponent;

--- a/src/MediaView.js
+++ b/src/MediaView.js
@@ -6,7 +6,7 @@ var cfg = {
         shouldNotifyLoadEvents: true
     },
     propTypes: {
-        nativeAdView: PropTypes.number | PropTypes.element,
+        // nativeAdView: PropTypes.number | PropTypes.element,
         ...View.propTypes
     }
 };

--- a/src/MediaView.js
+++ b/src/MediaView.js
@@ -1,0 +1,21 @@
+import React, { Component, PropTypes } from 'react';
+import { View, requireNativeComponent } from 'react-native';
+
+var cfg = {
+    nativeOnly: {
+        shouldNotifyLoadEvents: true
+    },
+    propTypes: {
+        nativeAdView: PropTypes.number | PropTypes.element,
+        ...View.propTypes
+    }
+};
+
+const MediaView = requireNativeComponent('CTKMediaView', null);
+
+
+const MediaViewComponent = props => {
+    return <MediaView {...props} />;
+}
+
+export default MediaViewComponent;

--- a/src/NativeAdClickable.js
+++ b/src/NativeAdClickable.js
@@ -6,7 +6,7 @@ var cfg = {
         shouldNotifyLoadEvents: true
     },
     propTypes: {
-        nativeAdView: PropTypes.number | PropTypes.element,
+        // nativeAdView: PropTypes.number | PropTypes.element,
         ...View.propTypes
     }
 };

--- a/src/NativeAdClickable.js
+++ b/src/NativeAdClickable.js
@@ -1,0 +1,27 @@
+import React, { Component, PropTypes } from 'react';
+import { View, requireNativeComponent } from 'react-native';
+
+var cfg = {
+    nativeOnly: {
+        shouldNotifyLoadEvents: true
+    },
+    propTypes: {
+        nativeAdView: PropTypes.number | PropTypes.element,
+        ...View.propTypes
+    }
+};
+
+const NativeAdClickable = requireNativeComponent('CTKNativeAdClickable', null);
+
+
+const NativeAdClickableComponent = props => {
+    return <NativeAdClickable {...props}>
+        {
+            React.Children.map(props.children,(child)=>{
+                return child;
+            })
+        }
+    </NativeAdClickable>;
+}
+
+export default NativeAdClickableComponent;

--- a/src/NativeAdsManager.js
+++ b/src/NativeAdsManager.js
@@ -61,6 +61,7 @@ class NativeAdsManager {
 
       if (isValid !== isValidNew) {
         if (isValidNew) {
+          this.lastError = null;
           this.eventEmitter.emit(EVENT_DID_BECOME_VALID);
         } else {
           this.eventEmitter.emit(EVENT_DID_BECOME_INVALID);
@@ -101,7 +102,6 @@ class NativeAdsManager {
     if (this.lastError) {
       // Already had error
       func(this.lastError);
-      this.lastError = null;
       return () => {};
     }
     this.eventEmitter.once(AD_MANAGER_ERROR, func);

--- a/src/NativeAdsManager.js
+++ b/src/NativeAdsManager.js
@@ -49,6 +49,13 @@ class NativeAdsManager {
 
     CTKNativeAdManager.init(placementId, adsToRequest);
   }
+  
+    /**
+     * Reload ads
+     */
+    reloadAds() {
+      CTKNativeAdManager.reloadAds(this.placementId);
+    }
 
   /**
    * Listens for AdManager state changes and updates internal state. When it changes,

--- a/src/android/src/main/java/io/callstack/react/fbads/AdChoiceViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/AdChoiceViewManager.java
@@ -1,0 +1,142 @@
+package io.callstack.react.fbads;
+
+import android.content.Context;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.RelativeLayout;
+
+import com.facebook.ads.*;
+import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.NativeViewHierarchyManager;
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIBlock;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.yoga.YogaMeasureFunction;
+import com.facebook.yoga.YogaMeasureMode;
+import com.facebook.yoga.YogaMeasureOutput;
+import com.facebook.yoga.YogaNode;
+
+/**
+ * Created by camlahoud on 8/30/17.
+ */
+
+public class AdChoiceViewManager extends SimpleViewManager<RelativeLayout> {
+    public final static String NAME = "CTKAdChoice";
+    private ThemedReactContext mContext;
+    private RelativeLayout mRootView = null;
+    private AdChoiceShadowNode shadowNode;
+
+    /**
+     * Get Name
+     */
+    @Override
+    public String getName() { return NAME; }
+
+    /**
+     * Create View Instance
+     *
+     */
+    @Override
+    public RelativeLayout createViewInstance(ThemedReactContext context) {
+        mContext = context;
+        mRootView = new RelativeLayout(context);
+        mRootView.setGravity(Gravity.RIGHT);
+        return mRootView;
+    }
+
+    @Override
+    public Class getShadowNodeClass() {
+        return AdChoiceShadowNode.class;
+    }
+
+    @Override
+    public LayoutShadowNode createShadowNodeInstance() {
+        shadowNode = new AdChoiceShadowNode();
+        return shadowNode;
+    }
+
+    /**
+     * Set the root reference to get the native ad view manager
+     */
+    @ReactProp(name = "nativeAdView")
+    public void setNativeAdView(final RelativeLayout view, final int tag) {
+        UIManagerModule uiManager = this.mContext.getNativeModule(UIManagerModule.class);
+        uiManager.addUIBlock(new UIBlock() {
+            @Override
+            public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+                NativeAdView v = (NativeAdView)nativeViewHierarchyManager.resolveView(tag);
+                NativeAd ad = v.getNativeAd();
+                final AdChoiceView adChoicesView = new AdChoiceView(mContext, ad, true);
+                mRootView.addView(adChoicesView);
+            }
+        });
+    }
+
+    public class AdChoiceShadowNode extends LayoutShadowNode implements YogaMeasureFunction {
+        protected int mWidth = 0;
+
+        public AdChoiceShadowNode() {
+            this.setMeasureFunction(this);
+        }
+
+        public void forceWidth (int width) {
+            mWidth = width;
+            dirty();
+        }
+
+        @Override
+        public long measure(
+                YogaNode node,
+                float width, YogaMeasureMode widthMode,
+                float height, YogaMeasureMode heightMode) {
+            if (mWidth > 0) {
+                return YogaMeasureOutput.make(mWidth, 50);
+            }
+            return YogaMeasureOutput.make(200, 50);
+        }
+
+        @ReactProp(name = "adsManager")
+        public void setAdsManager(String adsManagerId) {
+            dirty();
+        }
+    }
+
+    public class AdChoiceView extends AdChoicesView {
+
+        private RelativeLayout parentView = null;
+        private AdChoiceShadowNode mShadowNode;
+
+        public AdChoiceView(Context var1, NativeAd var2) {
+            this(var1, var2, false);
+        }
+
+        public AdChoiceView(Context var1, final NativeAd var2, boolean var3) {
+            super(var1, var2, var3);
+        }
+
+        @Override
+        public void requestLayout() {
+            super.requestLayout();
+//            mShadowNode = AdChoiceViewManager.this.shadowNode;
+            if (this.getParent()!=null) {
+                parentView = (RelativeLayout) this.getParent();
+            }
+            post(measureAndLayout);
+        }
+
+        private final Runnable measureAndLayout = new Runnable() {
+            @Override
+            public void run() {
+                if (parentView!=null) {
+                    parentView.measure(
+                            View.MeasureSpec.makeMeasureSpec(parentView.getWidth(), View.MeasureSpec.EXACTLY),
+                            View.MeasureSpec.makeMeasureSpec(parentView.getHeight(), View.MeasureSpec.EXACTLY));
+                    parentView.layout(parentView.getLeft(), parentView.getTop(), parentView.getRight(), parentView.getBottom());
+                }
+            }
+        };
+    }
+
+}

--- a/src/android/src/main/java/io/callstack/react/fbads/AdChoiceViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/AdChoiceViewManager.java
@@ -68,8 +68,10 @@ public class AdChoiceViewManager extends SimpleViewManager<RelativeLayout> {
             public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
                 NativeAdView v = (NativeAdView)nativeViewHierarchyManager.resolveView(tag);
                 NativeAd ad = v.getNativeAd();
-                final AdChoiceView adChoicesView = new AdChoiceView(mContext, ad, true);
-                mRootView.addView(adChoicesView);
+                if (ad != null) {
+                    final AdChoiceView adChoicesView = new AdChoiceView(mContext, ad, true);
+                    mRootView.addView(adChoicesView);
+                }
             }
         });
     }

--- a/src/android/src/main/java/io/callstack/react/fbads/FBAdsPackage.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/FBAdsPackage.java
@@ -38,8 +38,11 @@ public class FBAdsPackage implements ReactPackage {
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
+            new AdChoiceViewManager(),
            new NativeAdViewManager(reactContext),
-           new BannerViewManager(reactContext)
+           new BannerViewManager(reactContext),
+                new MediaViewManager(),
+                new NativeAdClickableViewManager()
         );
     }
 }

--- a/src/android/src/main/java/io/callstack/react/fbads/MediaViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/MediaViewManager.java
@@ -1,0 +1,72 @@
+package io.callstack.react.fbads;
+
+import android.view.Gravity;
+
+import com.facebook.ads.MediaView;
+import com.facebook.ads.NativeAd;
+import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.NativeViewHierarchyManager;
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIBlock;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+/**
+ * Created by camlahoud on 9/4/17.
+ */
+
+public class MediaViewManager extends SimpleViewManager<MediaView> {
+    public final static String NAME = "CTKMediaView";
+    private ThemedReactContext mContext;
+    private MediaView view = null;
+    private LayoutShadowNode shadowNode;
+
+    /**
+     * Get Name
+     */
+    @Override
+    public String getName() { return NAME; }
+
+    /**
+     * Create View Instance
+     *
+     */
+    @Override
+    public MediaView createViewInstance(ThemedReactContext context) {
+        mContext = context;
+        view = new MediaView(context);
+        view.setGravity(Gravity.CENTER);
+
+        return view;
+    }
+
+    @Override
+    public Class getShadowNodeClass() {
+        return LayoutShadowNode.class;
+    }
+
+    @Override
+    public LayoutShadowNode createShadowNodeInstance() {
+        shadowNode = new LayoutShadowNode();
+        shadowNode.setFlex(1.0f);
+        return shadowNode;
+    }
+
+    /**
+     * Set the root reference to get the native ad view manager
+     */
+    @ReactProp(name = "nativeAdView")
+    public void setNativeAdView(final MediaView view, final int tag) {
+        UIManagerModule uiManager = this.mContext.getNativeModule(UIManagerModule.class);
+        uiManager.addUIBlock(new UIBlock() {
+            @Override
+            public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+                NativeAdView v = (NativeAdView) nativeViewHierarchyManager.resolveView(tag);
+                NativeAd ad = v.getNativeAd();
+                view.setNativeAd(ad);
+            }
+        });
+    }
+
+}

--- a/src/android/src/main/java/io/callstack/react/fbads/MediaViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/MediaViewManager.java
@@ -1,5 +1,6 @@
 package io.callstack.react.fbads;
 
+import android.os.Handler;
 import android.view.Gravity;
 import android.view.View;
 
@@ -66,10 +67,16 @@ public class MediaViewManager extends SimpleViewManager<MediaView> {
                 NativeAdView v = (NativeAdView) nativeViewHierarchyManager.resolveView(tag);
                 NativeAd ad = v.getNativeAd();
                 view.setNativeAd(ad);
-                view.measure(
-                        View.MeasureSpec.makeMeasureSpec(view.getWidth(), View.MeasureSpec.EXACTLY),
-                        View.MeasureSpec.makeMeasureSpec(view.getHeight(), View.MeasureSpec.EXACTLY));
-                view.layout(view.getLeft(), view.getTop(), view.getRight(), view.getBottom());
+                Handler handler = new Handler();
+                handler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        view.measure(
+                                View.MeasureSpec.makeMeasureSpec(view.getWidth(), View.MeasureSpec.EXACTLY),
+                                View.MeasureSpec.makeMeasureSpec(view.getHeight(), View.MeasureSpec.EXACTLY));
+                        view.layout(view.getLeft(), view.getTop(), view.getRight(), view.getBottom());
+                    }
+                }, 3000);
             }
         });
     }

--- a/src/android/src/main/java/io/callstack/react/fbads/MediaViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/MediaViewManager.java
@@ -1,6 +1,7 @@
 package io.callstack.react.fbads;
 
 import android.view.Gravity;
+import android.view.View;
 
 import com.facebook.ads.MediaView;
 import com.facebook.ads.NativeAd;
@@ -65,6 +66,10 @@ public class MediaViewManager extends SimpleViewManager<MediaView> {
                 NativeAdView v = (NativeAdView) nativeViewHierarchyManager.resolveView(tag);
                 NativeAd ad = v.getNativeAd();
                 view.setNativeAd(ad);
+                view.measure(
+                        View.MeasureSpec.makeMeasureSpec(view.getWidth(), View.MeasureSpec.EXACTLY),
+                        View.MeasureSpec.makeMeasureSpec(view.getHeight(), View.MeasureSpec.EXACTLY));
+                view.layout(view.getLeft(), view.getTop(), view.getRight(), view.getBottom());
             }
         });
     }

--- a/src/android/src/main/java/io/callstack/react/fbads/NativeAdClickableViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/NativeAdClickableViewManager.java
@@ -74,18 +74,6 @@ public class NativeAdClickableViewManager extends ViewGroupManager<ReactViewGrou
         return view;
     }
 
-    @Override
-    public Class getShadowNodeClass() {
-        return LayoutShadowNode.class;
-    }
-
-    @Override
-    public LayoutShadowNode createShadowNodeInstance() {
-        shadowNode = new LayoutShadowNode();
-        shadowNode.setFlex(1.0f);
-        return shadowNode;
-    }
-
     /**
      * Set the root reference to get the native ad view manager
      */

--- a/src/android/src/main/java/io/callstack/react/fbads/NativeAdClickableViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/NativeAdClickableViewManager.java
@@ -1,0 +1,103 @@
+package io.callstack.react.fbads;
+
+import android.view.MotionEvent;
+import android.view.View;
+
+import com.facebook.ads.NativeAd;
+import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.NativeViewHierarchyManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIBlock;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.views.view.ReactViewGroup;
+
+import java.util.List;
+
+/**
+ * Created by camlahoud on 9/4/17.
+ */
+
+public class NativeAdClickableViewManager extends ViewGroupManager<ReactViewGroup> {
+    public final static String NAME = "CTKNativeAdClickable";
+    private ThemedReactContext mContext;
+    private ReactViewGroup view = null;
+    private ReactViewGroup clickableView = null;
+    private LayoutShadowNode shadowNode;
+
+    /** The NativeAdView containing this clickable */
+    private NativeAdView mRootView;
+
+    /** NativeAd displayed */
+    private NativeAd mNativeAd;
+
+    /** @{float} x coordinate where the touch event started **/
+    private float startX;
+
+    /** @{float} y coordinate where the touche event started **/
+    private float startY;
+
+    /**
+     * Get Name
+     */
+    @Override
+    public String getName() { return NAME; }
+
+    /**
+     * Create View Instance
+     *
+     */
+    @Override
+    public ReactViewGroup createViewInstance(ThemedReactContext context) {
+        mContext = context;
+        view = new ReactViewGroup(context);
+        view.setOnTouchListener(new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View v, MotionEvent ev) {
+                switch (ev.getActionMasked()) {
+                    case MotionEvent.ACTION_DOWN:
+                        startX = ev.getX();
+                        startY = ev.getY();
+                        break;
+                    case MotionEvent.ACTION_UP:
+                        float deltaX = Math.abs(startX - ev.getX());
+                        float deltaY = Math.abs(startY - ev.getY());
+                        if (deltaX < 200 & deltaY < 200) {
+                            v.performClick();
+                        }
+                        break;
+                }
+                return true;
+            }
+        });
+        return view;
+    }
+
+    @Override
+    public Class getShadowNodeClass() {
+        return LayoutShadowNode.class;
+    }
+
+    @Override
+    public LayoutShadowNode createShadowNodeInstance() {
+        shadowNode = new LayoutShadowNode();
+        shadowNode.setFlex(1.0f);
+        return shadowNode;
+    }
+
+    /**
+     * Set the root reference to get the native ad view manager
+     */
+    @ReactProp(name = "nativeAdView")
+    public void setNativeAdView(final ReactViewGroup view, final int tag) {
+        UIManagerModule uiManager = this.mContext.getNativeModule(UIManagerModule.class);
+        uiManager.addUIBlock(new UIBlock() {
+            @Override
+            public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+                mRootView = (NativeAdView)nativeViewHierarchyManager.resolveView(tag);
+                mRootView.addClickableView(view);
+            }
+        });
+    }
+}

--- a/src/android/src/main/java/io/callstack/react/fbads/NativeAdClickableViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/NativeAdClickableViewManager.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 public class NativeAdClickableViewManager extends ViewGroupManager<ReactViewGroup> {
     public final static String NAME = "CTKNativeAdClickable";
+    public final static String LOGTAG = "ReactNative";
     private ThemedReactContext mContext;
     private ReactViewGroup view = null;
     private ReactViewGroup clickableView = null;
@@ -79,13 +80,17 @@ public class NativeAdClickableViewManager extends ViewGroupManager<ReactViewGrou
      */
     @ReactProp(name = "nativeAdView")
     public void setNativeAdView(final ReactViewGroup view, final int tag) {
-        UIManagerModule uiManager = this.mContext.getNativeModule(UIManagerModule.class);
-        uiManager.addUIBlock(new UIBlock() {
-            @Override
-            public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
-                mRootView = (NativeAdView)nativeViewHierarchyManager.resolveView(tag);
-                mRootView.addClickableView(view);
-            }
-        });
+        try {
+            UIManagerModule uiManager = this.mContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                @Override
+                public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+                    mRootView = (NativeAdView) nativeViewHierarchyManager.resolveView(tag);
+                    mRootView.addClickableView(view);
+                }
+            });
+        } catch (Exception e) {
+            Log.e(LOGTAG, e.getMessage());
+        }
     }
 }

--- a/src/android/src/main/java/io/callstack/react/fbads/NativeAdManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/NativeAdManager.java
@@ -65,6 +65,15 @@ public class NativeAdManager extends ReactContextBaseJavaModule implements Nativ
     }
 
     /**
+     * Reload ads
+     */
+    @ReactMethod
+    public void reloadAds(String placementId) {
+        NativeAdsManager adsManager = mAdsManagers.get(placementId);
+        adsManager.loadAds();
+    }
+
+    /**
      * Disables auto refresh
      *
      * @param placementId

--- a/src/android/src/main/java/io/callstack/react/fbads/NativeAdManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/NativeAdManager.java
@@ -100,6 +100,10 @@ public class NativeAdManager extends ReactContextBaseJavaModule implements Nativ
     @Override
     public void onAdError(AdError adError) {
         // @todo handle errors here
+        WritableMap error = Arguments.createMap();
+        error.putInt("code", adError.getErrorCode());
+        error.putString("message", adError.getErrorMessage());
+        sendAppEvent("CTKNativeAdsManagersError", error);
     }
 
     /**

--- a/src/android/src/main/java/io/callstack/react/fbads/NativeAdManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/NativeAdManager.java
@@ -10,6 +10,7 @@ package io.callstack.react.fbads;
 import android.util.Log;
 
 import com.facebook.ads.AdError;
+import com.facebook.ads.NativeAd;
 import com.facebook.ads.NativeAdsManager;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -25,6 +26,9 @@ import java.util.Map;
 public class NativeAdManager extends ReactContextBaseJavaModule implements NativeAdsManager.Listener {
     /** @{Map} with all registered fb ads managers **/
     private Map<String, NativeAdsManager> mAdsManagers = new HashMap<>();
+
+    /** @{Map} with latest NativeAd from all managers **/
+    private Map<String, NativeAd> mLatestAds = new HashMap<>();
 
     public NativeAdManager(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -114,6 +118,35 @@ public class NativeAdManager extends ReactContextBaseJavaModule implements Nativ
      */
     public NativeAdsManager getFBAdsManager(String placementId) {
         return mAdsManagers.get(placementId);
+    }
+
+    /**
+     * Returns the next native ad for the given placement
+     *
+     * @param placementId
+     * @return
+     */
+    public NativeAd getNextNativeAd(String placementId) {
+        NativeAdsManager adsManager = this.getFBAdsManager(placementId);
+        NativeAd ad = adsManager.nextNativeAd();
+        mLatestAds.put(placementId, ad);
+        return ad;
+    }
+
+    /**
+     * Returns the latest native ad for the given placement
+     *
+     * @param placementId
+     * @return NativeAd
+     */
+    public NativeAd getLastNativeAd(String placementId) {
+        NativeAd ad;
+        if (mLatestAds.containsKey(placementId)) {
+            ad = mLatestAds.get(placementId);
+        } else {
+            ad = this.getNextNativeAd(placementId);
+        }
+        return ad;
     }
 
     /**

--- a/src/android/src/main/java/io/callstack/react/fbads/NativeAdView.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/NativeAdView.java
@@ -65,6 +65,8 @@ public class NativeAdView extends ReactViewGroup {
         event.putString("subtitle", nativeAd.getAdSubtitle());
         event.putString("description", nativeAd.getAdBody());
         event.putString("callToActionText", nativeAd.getAdCallToAction());
+        event.putString("adChoiceIconUrl", nativeAd.getAdChoicesIcon().getUrl());
+        event.putString("adChoiceLinkUrl", nativeAd.getAdChoicesLinkUrl());
 
         // Check as they might be null because of memory issues on low-end devices
         if (coverImage != null) {

--- a/src/android/src/main/java/io/callstack/react/fbads/NativeAdViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/NativeAdViewManager.java
@@ -15,13 +15,18 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIBlock;
+import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class NativeAdViewManager extends ViewGroupManager<NativeAdView> {
     ReactApplicationContext mReactContext;
+    NativeAdView mView;
 
     public NativeAdViewManager(ReactApplicationContext reactContext) {
         super();
@@ -35,15 +40,23 @@ public class NativeAdViewManager extends ViewGroupManager<NativeAdView> {
 
     @Override
     protected NativeAdView createViewInstance(ThemedReactContext reactContext) {
-        return new NativeAdView(reactContext);
+        mView = new NativeAdView(reactContext);
+        return mView;
     }
 
     @ReactProp(name = "adsManager")
     public void setAdsManager(NativeAdView view, String adsManagerId) {
         NativeAdManager adManager = mReactContext.getNativeModule(NativeAdManager.class);
-        NativeAdsManager adsManager = adManager.getFBAdsManager(adsManagerId);
+        view.setNativeAd(adManager.getNextNativeAd(adsManagerId));
 
-        view.setNativeAd(adsManager.nextNativeAd());
+//        NativeAdsManager adsManager = adManager.getFBAdsManager(adsManagerId);
+
+//        view.setNativeAd(adsManager.nextNativeAd());
+    }
+
+    @ReactProp(name = "clickable")
+    public void setClickable(NativeAdView view, Boolean clickable) {
+        view.setAdClickable(clickable);
     }
 
     @Override

--- a/src/index.js
+++ b/src/index.js
@@ -13,3 +13,6 @@ export { default as AdSettings } from './AdSettings';
 export { default as NativeAdsManager } from './NativeAdsManager';
 export { default as InterstitialAdManager } from './InterstitialAdManager';
 export { default as BannerView } from './BannerViewManager';
+export { default as AdChoices } from './AdChoices';
+export { default as MediaView } from './MediaView';
+export { default as NativeAdClickable } from './NativeAdClickable';

--- a/src/withNativeAd.js
+++ b/src/withNativeAd.js
@@ -51,11 +51,22 @@ export default (Component: Function) => class NativeAdWrapper extends React.Comp
     );
   }
 
+  componentWillMount() {
+    this.removeErrorSubscription = this.props.adsManager.onAdsError(
+      (error) => {
+        if (this.props.onAdError) {
+          this.props.onAdError(error);
+        }
+      }
+    );
+  }
+
   /**
    * Clear subscription when component goes off screen
    */
   componentWillUnmount() {
     this.removeSubscription();
+    this.removeErrorSubscription();
   }
 
   render() {

--- a/src/withNativeAd.js
+++ b/src/withNativeAd.js
@@ -9,7 +9,7 @@
  */
 
 import React from 'react';
-import { requireNativeComponent } from 'react-native';
+import { requireNativeComponent, findNodeHandle } from 'react-native';
 import AdsManager from './NativeAdsManager';
 import type { NativeAd } from './types';
 
@@ -22,6 +22,7 @@ type NativeAdWrapperState = {
 
 type NativeAdWrapperProps = {
   adsManager: AdsManager,
+  clickable: boolean
 };
 
 /**
@@ -70,7 +71,7 @@ export default (Component: Function) => class NativeAdWrapper extends React.Comp
   }
 
   render() {
-    const { adsManager, ...props } = this.props;
+    const { adsManager, clickable, ...props } = this.props;
 
     if (!this.state.canRequestAds) {
       return null;
@@ -80,8 +81,10 @@ export default (Component: Function) => class NativeAdWrapper extends React.Comp
       <NativeAdView
         adsManager={adsManager.toJSON()}
         onAdLoaded={(e) => this.setState({ ad: e.nativeEvent })}
+        clickable={clickable}
+        ref={root => this.rootRef = findNodeHandle(root)}
       >
-        {this.state.ad && <Component nativeAd={this.state.ad} {...props} />}
+        {this.state.ad && <Component nativeAd={this.state.ad} {...props} nativeAdView={this.rootRef} />}
       </NativeAdView>
     );
   }


### PR DESCRIPTION
Created a native implementation using the AdChoices component on android. Also created a NativeAdClickable component which can be used to define specific views to attach the click event to, instead of making the whole ad view clickable.

By default I made the NativeAdView not clickable, but you can restore the previous behaviour (of having the whole component clickable) by passing `clickable={true}` to the native ad component.

