### PR TITLE
Update BannerViewManager.java

### DIFF
--- a/src/android/src/main/java/io/callstack/react/fbads/BannerViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/BannerViewManager.java
@@ -51,7 +51,9 @@ public class BannerViewManager extends SimpleViewManager<BannerView> {
       "onAdPress",
       MapBuilder.of("registrationName", "onAdPress"),
       "onAdError",
-      MapBuilder.of("registrationName", "onAdError")
+      MapBuilder.of("registrationName", "onAdError"),
+      "onLoggingImpression",
+      MapBuilder.of("registrationName", "onLoggingImpression")
     );
   }
 


### PR DESCRIPTION
Add `onLoggingImpresssion` as a custom event

This solves the `Unsupported top level event type "onLoggingImpression" dispacted` issue https://github.com/callstack/react-native-fbads/issues/87