### PR TITLE
Fix banner view rectangle support

### DIFF
--- a/src/android/src/main/java/io/callstack/react/fbads/BannerViewManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/BannerViewManager.java
@@ -33,6 +33,7 @@ public class BannerViewManager extends SimpleViewManager<BannerView> {
         break;
       case 250:
         adSize = AdSize.RECTANGLE_HEIGHT_250;
+        break;
       case 50:
       default:
         adSize = AdSize.BANNER_HEIGHT_50;


### PR DESCRIPTION
There was a break statement missing which made
it impossible to use the rectangle height 250
banner ad size.