### PR TITLE
upgrade to 4.28.2

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -36,5 +36,5 @@ repositories {
 dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:appcompat-v7:23.1.0'
-    compile 'com.facebook.android:audience-network-sdk:4.24.0'
+    compile 'com.facebook.android:audience-network-sdk:4.28.2'
 }


### PR DESCRIPTION
the current version (4.24.0) has a number of crashes which have since been fixed:
https://developers.facebook.com/docs/audience-network/changelog-android

there is a newer version, 4.99.x but introduces a number of API changes so I did not update to that.