### PR TITLE
Fix AdChoicesManager Side Effects

### DIFF
--- a/AdChoicesManager.js
+++ b/AdChoicesManager.js
@@ -3,8 +3,11 @@ import {requireNativeComponent, StyleSheet, Platform} from 'react-native';
 
 const NativeAdChoicesView = requireNativeComponent('AdChoicesView', null);
 
+type adChoiceLocation = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+
 export default class AdChoicesView extends React.Component<Object> {
-    render() {
+    
+    render() {   
         if (!this.props.placementId) {
             return null;
         }
@@ -12,13 +15,13 @@ export default class AdChoicesView extends React.Component<Object> {
         return (
             <NativeAdChoicesView
                 placementId={this.props.placementId}
-                style={[styles.adChoice, this.getPositionStyle()]}
+                style={[styles.adChoice, this.getPositionStyle(this.props.position)]}
                 location={this.props.position || 'topRight'}/>
         );
     }
 
-    getPositionStyle = () => {
-        switch (this.props.position) {
+    getPositionStyle = (position: adChoiceLocation) => {
+        switch (position) {
             case 'topLeft':
                 return styles.topLeft;
             case 'topRight':
@@ -28,7 +31,7 @@ export default class AdChoicesView extends React.Component<Object> {
             case 'bottomRight':
                 return styles.bottomRight;
             default:
-                return null;
+                return styles.topLeft;
         }
     }
 }

--- a/AdChoicesManager.js
+++ b/AdChoicesManager.js
@@ -26,12 +26,6 @@ export default class AdChoicesView extends React.Component<Object> {
         }
     }
 
-    componentWillUpdate(nextProps) {
-        if (this.props.placementId !== nextProps.placementId) {
-            this.props.placementId = nextProps.placementId
-        }
-    }
-
     render() {
         if (!this.props.placementId) {
             return null;

--- a/AdChoicesManager.js
+++ b/AdChoicesManager.js
@@ -2,40 +2,34 @@ import React, {PropTypes} from 'react';
 import {requireNativeComponent, StyleSheet, Platform} from 'react-native';
 
 const NativeAdChoicesView = requireNativeComponent('AdChoicesView', null);
-let positionStyle = null;
-
-type adChoiceLocation = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
 
 export default class AdChoicesView extends React.Component<Object> {
-
-    location: adChoiceLocation;
-
-    componentWillMount() {
-        positionStyle = styles.topRight;
-
-        location = this.props.position;
-
-        if (location === 'topLeft') {
-            positionStyle = styles.topLeft
-        } else if (location === 'topRight') {
-            positionStyle = styles.topRight
-        } else if (location === 'bottomLeft') {
-            positionStyle = styles.bottomLeft
-        } else if (location === 'bottomRight') {
-            positionStyle = styles.bottomRight
-        }
-    }
-
     render() {
         if (!this.props.placementId) {
             return null;
         }
+
         return (
             <NativeAdChoicesView
                 placementId={this.props.placementId}
-                style={[styles.adChoice, positionStyle]}
+                style={[styles.adChoice, this.getPositionStyle()]}
                 location={this.props.position || 'topRight'}/>
         );
+    }
+
+    getPositionStyle = () => {
+        switch (this.props.position) {
+            case 'topLeft':
+                return styles.topLeft;
+            case 'topRight':
+                return styles.topRight;
+            case 'bottomLeft':
+                return styles.bottomLeft;
+            case 'bottomRight':
+                return styles.bottomRight;
+            default:
+                return null;
+        }
     }
 }
 


### PR DESCRIPTION
The current implementation of AdChoicesManager has a few bad practices going on:
- Props mutation in `componentWillUpdate`
- Assignment to a static `positionStyle` from the current props, which causes components with different props to render incorrectly, as they affect the same `positionStyle`.

This PR addresses both issues.

### Discussion
This project seems like an important part of the React Native OSS community, but the current master is broken, and README.md is referring to an unreleased version (and is also inaccurate)

I think it's important to keep in mind that this project is probably the go-to implementation of many developers looking to integrate facebook ads into RN.

I'd like to suggest the following:
- Enforce ESLint. The current master does not pass validation, this perhaps should be a precondition for a PR to land.
- Add a package lock file (yarn / npm)
- Configure a code formatter such as Prettier to enforce code style.

These changes make it much easier for other developers, myself included, to contribute to this project.

I'd be happy to submit a PR for that as well.

I'm also wondering why the current master android package was changed from the callstack domain to @Suraj-Tiwari's.