### PR TITLE
Add AdChoicesManager Types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -37,8 +37,6 @@ module.system=haste
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 
-experimental.strict_type_args=true
-
 munge_underscores=true
 
 module.name_mapper='^image![a-zA-Z0-9$_-]+$' -> 'GlobalImageStub'
@@ -52,7 +50,5 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(3[0-2]\\|[1
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(3[0-2]\\|1[0-9]\\|[1-2][0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
-unsafe.enable_getters_and_setters=true
-
 [version]
-^0.30.0
+>=0.80.0

--- a/AdChoicesManager.js
+++ b/AdChoicesManager.js
@@ -1,5 +1,4 @@
 // @flow
-
 import React, {PropTypes} from 'react';
 import { requireNativeComponent, StyleSheet, Platform } from 'react-native';
 

--- a/AdChoicesManager.js
+++ b/AdChoicesManager.js
@@ -1,11 +1,24 @@
+// @flow
+
 import React, {PropTypes} from 'react';
-import {requireNativeComponent, StyleSheet, Platform} from 'react-native';
+import { requireNativeComponent, StyleSheet, Platform } from 'react-native';
 
 const NativeAdChoicesView = requireNativeComponent('AdChoicesView', null);
 
-type adChoiceLocation = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+type AdChoicePosition = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
 
-export default class AdChoicesView extends React.Component<Object> {
+type Props = {
+    placementId: string | null;
+    position: AdChoicePosition;
+    expandable: boolean;
+}
+
+export default class AdChoicesView extends React.Component<Props> {
+    static defaultProps : Props = {
+        position: 'topLeft',
+        placementId: null,
+        expandable: false
+    }
     
     render() {   
         if (!this.props.placementId) {
@@ -14,13 +27,15 @@ export default class AdChoicesView extends React.Component<Object> {
 
         return (
             <NativeAdChoicesView
-                placementId={this.props.placementId}
                 style={[styles.adChoice, this.getPositionStyle(this.props.position)]}
-                location={this.props.position || 'topRight'}/>
+                placementId={this.props.placementId}
+                location={this.props.position}
+                expandable={this.props.expandable}
+            />
         );
     }
 
-    getPositionStyle = (position: adChoiceLocation) => {
+    getPositionStyle = (position: AdChoicePosition) => {
         switch (position) {
             case 'topLeft':
                 return styles.topLeft;
@@ -31,7 +46,7 @@ export default class AdChoicesView extends React.Component<Object> {
             case 'bottomRight':
                 return styles.bottomRight;
             default:
-                return styles.topLeft;
+                throw new Error(`Unsupported position ${position}`)
         }
     }
 }

--- a/withNativeAd.js
+++ b/withNativeAd.js
@@ -1,3 +1,4 @@
+// @flow
 import * as React from 'react';
 import {EmitterSubscription} from 'fbemitter';
 import {requireNativeComponent, findNodeHandle, Text, View} from 'react-native';

--- a/withNativeAd.js
+++ b/withNativeAd.js
@@ -33,7 +33,8 @@ type NativeAdWrapperState = {
 type NativeAdWrapperProps = {
     adsManager: AdsManager,
     onAdLoaded?: ?(?NativeAd) => void,
-    adChoicePosition?: ?string
+    adChoicePosition?: ?string,
+    expandable?: ?boolean
 };
 
 type MultipleRegisterablesContextValueType = {


### PR DESCRIPTION
Continues https://github.com/callstack/react-native-fbads/pull/115 which was merged prematurely.
This branch adds types for the component props as well as default props.

@Suraj-Tiwari After re-activating type checking I found some errors, including [this line which compares an array with a number](https://github.com/callstack/react-native-fbads/blob/master/withNativeAd.js#L114) (instead of comparing it's length), which I'll address in a different PR.
