### PR TITLE
[Android] Fix AdChoices Multi DPI Layout

### DIFF
--- a/android/app/src/main/java/suraj/tiwari/reactnativefbads/NativeAdChoicesView.java
+++ b/android/app/src/main/java/suraj/tiwari/reactnativefbads/NativeAdChoicesView.java
@@ -7,24 +7,32 @@
  */
 package suraj.tiwari.reactnativefbads;
 
-import com.facebook.ads.NativeAd;
+import android.util.TypedValue;
 import com.facebook.ads.AdChoicesView;
+import com.facebook.ads.NativeAd;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.view.ReactViewGroup;
 
 public class NativeAdChoicesView extends ReactViewGroup {
+  private static final int ICON_SIZE = 22;
 
   private ReactContext mContext;
-   public NativeAdChoicesView(ThemedReactContext context) {
+
+  public NativeAdChoicesView(ThemedReactContext context) {
     super(context);
     mContext = context;
   }
 
   public void setNativeAd(NativeAd nativeAd) {
     AdChoicesView adChoicesView = new AdChoicesView(mContext, nativeAd, true);
-    adChoicesView.measure(40, 40);
-    adChoicesView.layout(0, 0, 40, 40);
+
+    int size = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, ICON_SIZE,
+        mContext.getResources().getDisplayMetrics());
+
+    adChoicesView.measure(size, size);
+    adChoicesView.layout(0, 0, size, size);
+
     adChoicesView.bringToFront();
     addView(adChoicesView);
   }


### PR DESCRIPTION
The native `AdChoicesView` uses hardcoded pixel dimensions, which causes the view's layout to break in larger devices. 

This PR converts the hardcoded pixels to DP units to resolve this issue.