### PR TITLE
Extract AdChoices Component

### DIFF
--- a/AdChoicesManager.js
+++ b/AdChoicesManager.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { PropTypes } from 'react';
 import { requireNativeComponent, StyleSheet, Platform } from 'react-native';
-import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet'
+import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 const NativeAdChoicesView = requireNativeComponent('AdChoicesView', null);
 
@@ -11,7 +11,7 @@ type Props = {
   placementId: string | null,
   location: AdChoiceLocation,
   expandable: boolean,
-  style?: ViewStyleProp;
+  style?: ViewStyleProp
 };
 
 export default class AdChoicesView extends React.Component<Props> {
@@ -49,6 +49,6 @@ let styles = StyleSheet.create({
         width: 22,
         height: 22
       }
-    }),
+    })
   }
 });

--- a/AdChoicesManager.js
+++ b/AdChoicesManager.js
@@ -3,12 +3,14 @@ import React, { PropTypes } from 'react';
 import { requireNativeComponent, StyleSheet, Platform } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
+import { AdChoicesViewContext } from './withNativeAd';
+import type { AdChoicesViewContextValueType } from './withNativeAd';
+
 const NativeAdChoicesView = requireNativeComponent('AdChoicesView', null);
 
 type AdChoiceLocation = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
 
 type Props = {
-  placementId: string | null,
   location: AdChoiceLocation,
   expandable: boolean,
   style?: ViewStyleProp
@@ -17,22 +19,21 @@ type Props = {
 export default class AdChoicesView extends React.Component<Props> {
   static defaultProps: Props = {
     location: 'topLeft',
-    placementId: null,
     expandable: false
   };
 
   render() {
-    if (!this.props.placementId) {
-      return null;
-    }
-
     return (
-      <NativeAdChoicesView
-        style={[styles.adChoice, this.props.style]}
-        placementId={this.props.placementId}
-        location={this.props.location}
-        expandable={this.props.expandable}
-      />
+      <AdChoicesViewContext.Consumer>
+        {(placementId: AdChoicesViewContextValueType) => (
+          <NativeAdChoicesView
+            style={[styles.adChoice, this.props.style]}
+            placementId={placementId}
+            location={this.props.location}
+            expandable={this.props.expandable}
+          />
+        )}
+      </AdChoicesViewContext.Consumer>
     );
   }
 }

--- a/AdChoicesManager.js
+++ b/AdChoicesManager.js
@@ -1,20 +1,22 @@
 // @flow
 import React, { PropTypes } from 'react';
 import { requireNativeComponent, StyleSheet, Platform } from 'react-native';
+import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet'
 
 const NativeAdChoicesView = requireNativeComponent('AdChoicesView', null);
 
-type AdChoicePosition = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+type AdChoiceLocation = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
 
 type Props = {
   placementId: string | null,
-  position: AdChoicePosition,
-  expandable: boolean
+  location: AdChoiceLocation,
+  expandable: boolean,
+  style?: ViewStyleProp;
 };
 
 export default class AdChoicesView extends React.Component<Props> {
   static defaultProps: Props = {
-    position: 'topLeft',
+    location: 'topLeft',
     placementId: null,
     expandable: false
   };
@@ -26,28 +28,13 @@ export default class AdChoicesView extends React.Component<Props> {
 
     return (
       <NativeAdChoicesView
-        style={[styles.adChoice, this.getPositionStyle(this.props.position)]}
+        style={[styles.adChoice, this.props.style]}
         placementId={this.props.placementId}
-        location={this.props.position}
+        location={this.props.location}
         expandable={this.props.expandable}
       />
     );
   }
-
-  getPositionStyle = (position: AdChoicePosition) => {
-    switch (position) {
-      case 'topLeft':
-        return styles.topLeft;
-      case 'topRight':
-        return styles.topRight;
-      case 'bottomLeft':
-        return styles.bottomLeft;
-      case 'bottomRight':
-        return styles.bottomRight;
-      default:
-        throw new Error(`Unsupported position ${position}`);
-    }
-  };
 }
 
 let styles = StyleSheet.create({
@@ -63,22 +50,5 @@ let styles = StyleSheet.create({
         height: 22
       }
     }),
-    position: 'absolute'
-  },
-  topLeft: {
-    left: 0,
-    top: 0
-  },
-  topRight: {
-    top: 0,
-    right: 0
-  },
-  bottomLeft: {
-    left: 0,
-    bottom: 0
-  },
-  bottomRight: {
-    bottom: 0,
-    right: 0
   }
 });

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-react-native-fbads [![npm version][version-badge]][package]
-============
+# react-native-fbads [![npm version][version-badge]][package]
 
 [![chat][chat-badge]][chat]
 
@@ -15,47 +14,51 @@ react-native-fbads [![npm version][version-badge]][package]
     - [iOS](#21-ios)
     - [Android](#22-android)
 - [Usage](#usage)
-   - [Interstitial Ads](#interstitial-ads)
-      - [1. Showing ad](#1-showing-ad)
-   - [Native Ads](#native-ads)
-      - [1. Creating AdsManager](#1-creating-adsmanager)
-      - [2. Making ad component](#2-making-ad-component)
-      - [3. Rendering an ad](#3-rendering-an-ad)
-   - [Banner View](#bannerview)
-      - [1. Showing ad](#1-showing-ad-1)
+  - [Interstitial Ads](#interstitial-ads)
+    - [1. Showing ad](#1-showing-ad)
+  - [Native Ads](#native-ads)
+    - [1. Creating AdsManager](#1-creating-adsmanager)
+    - [2. Making ad component](#2-making-ad-component)
+    - [3. Rendering an ad](#3-rendering-an-ad)
+  - [Banner View](#bannerview)
+    - [1. Showing ad](#1-showing-ad-1)
 - [API](#api)
-    - [NativeAdsManager](#nativeadsmanager)
-      - [disableAutoRefresh](#disableautorefresh)
-      - [setMediaCachePolicy](#setmediacachepolicy)
-    - [InterstitialAdManager](#interstitialadmanager)
-      - [showAd](#showad)
-    - [RewardedVideoAdManager](#rewardedvideoadmanager)
-      - [loadAd](#loadAd)
-      - [showAd](#showAd)
-    - [AdSettings](#adsettings)
-      - [currentDeviceHash](#currentdevicehash)
-      - [addTestDevice](#addtestdevice)
-      - [clearTestDevices](#cleartestdevices)
-      - [setLogLevel](#setloglevel)
-      - [setIsChildDirected](#setischilddirected)
-      - [setMediationService](#setmediationservice)
-      - [setUrlPrefix](#seturlprefix)
+  - [NativeAdsManager](#nativeadsmanager)
+    - [disableAutoRefresh](#disableautorefresh)
+    - [setMediaCachePolicy](#setmediacachepolicy)
+  - [InterstitialAdManager](#interstitialadmanager)
+    - [showAd](#showad)
+  - [RewardedVideoAdManager](#rewardedvideoadmanager)
+    - [loadAd](#loadAd)
+    - [showAd](#showAd)
+  - [AdSettings](#adsettings)
+    - [currentDeviceHash](#currentdevicehash)
+    - [addTestDevice](#addtestdevice)
+    - [clearTestDevices](#cleartestdevices)
+    - [setLogLevel](#setloglevel)
+    - [setIsChildDirected](#setischilddirected)
+    - [setMediationService](#setmediationservice)
+    - [setUrlPrefix](#seturlprefix)
 - [Running example](#running-example)
-   - [Install dependencies](#1-install-dependencies)
-   - [Start packager](#2-start-packager)
-   - [Run it on iOS / Android](#3-run-it-on-ios--android)
+  - [Install dependencies](#1-install-dependencies)
+  - [Start packager](#2-start-packager)
+  - [Run it on iOS / Android](#3-run-it-on-ios--android)
 - [Credits](#credits)
 
 ## Installation
 
 ### 1. Install Javascript packages
+
 ##### RN >= 0.40
+
 Install JavaScript packages:
 
 ```bash
 $ react-native install react-native-fbads
 ```
+
 ##### RN < 0.40
+
 Install JavaScript packages:
 
 ```bash
@@ -73,7 +76,6 @@ react-native link react-native-fbads
 
 //IOS NOTICE
 Use pod to install fbAudience framework
-
 ```
 
 ### 2. Configure native projects
@@ -111,7 +113,7 @@ import { InterstitialAdManager } from 'react-native-fbads';
 
 InterstitialAdManager.showAd(placementId)
   .then(didClick => {})
-  .catch(error => {})
+  .catch(error => {});
 ```
 
 Method returns a promise that will be rejected when an error occurs during a call (e.g. no fill from ad server or network error) and resolve when user either dimisses or interacts with the displayed ad.
@@ -134,11 +136,11 @@ const adsManager = new NativeAdsManager(placementId, numberOfAdsToRequest);
 ```
 
 The constructor accepts two parameters:
+
 - `placementId` - which is an unique identifier describing your ad units,
 - `numberOfAdsToRequest` - which is a number of ads to request by ads manager at a time
 
 #### 2. Making ad component
-
 
 After creating `adsManager` instance, next step is to wrap an arbitrary component that you want to
 use for rendering your custom advertises with a `withNativeAd` wrapper.
@@ -158,22 +160,26 @@ The `nativeAd` object can contain the following properties:
 - `callToActionText` - Call to action phrase, e.g. - "Install Now"
 - `socialContext` - social context for the Ad, for example "Over half a million users"
 
-
 ** Note: ** Don't use more than one MediaView/AdIconView component within one native ad.
 
 ** Note: ** To make any text `Triggerable` wrap it in <TriggerableView></TriggerableView> use only <Text /> component
 
-
 ```js
-import { AdIconView,MediaView,TriggerableView } from 'react-native-ads-facebook';
+import {
+  AdIconView,
+  MediaView,
+  AdChoicesView,
+  TriggerableView
+} from 'react-native-fbads';
 class AdComponent extends React.Component {
   render() {
     return (
       <View>
+        <AdChoicesView style={{ position: 'absolute', left: 0, top: 0 }} />
         <AdIconView />
         <MediaView />
         <TriggerableView>
-            <Text>{this.props.nativeAd.description}</Text>
+          <Text>{this.props.nativeAd.description}</Text>
         </TriggerableView>
       </View>
     );
@@ -184,22 +190,24 @@ export default withNativeAd(AdComponent);
 ```
 
 #### 4. Displaying Facebook Ad Choices Icon
-Facebook's guidelines require every native ad to include the Ad Choices component, which contains a small clickable icon.
 
-Example usage:
+Facebook's guidelines require every native ad to include the Ad Choices component, which contains a small clickable icon.
+You can use the included `AdChoicesView` component and style it to your liking.
+
+#### Example usage
+
 ```js
 import { AdChoicesView } from 'react-native-fbads'
 
-...
-
 <AdChoicesView style={{position:'absolute', left:0, top:0}}/>
 ```
-| prop | default | required  | description |
-|------|---------|-----------|-------------|
-| style | undefined | false | Standard Style prop |
-| expandable | false | false | (iOS only) makes the native AdChoices expandable |
-| location | topLeft | false | (iOS only) controls the location of the AdChoices icon
 
+#### Props
+| prop       | default   | required | description                                            |
+| ---------- | --------- | -------- | ------------------------------------------------------ |
+| style      | undefined | false    | Standard Style prop                                    |
+| expandable | false     | false    | (iOS only) makes the native AdChoices expandable       |
+| location   | topLeft   | false    | (iOS only) controls the location of the AdChoices icon |
 
 #### 3. Rendering an ad
 
@@ -208,9 +216,9 @@ of your choice.
 
 ##### Native Ad Props
 
-| prop | default | required | params | description |
-|------------------|----------|----------|-----------------------------------------------------------------------------|----------------------------------|
-| adsManager | null | true | `const adsManager = new NativeAdsManager(placementId, numberOfAdsToRequest)` | The ad manager to work with |
+| prop       | default | required | params                                                                       | description                 |
+| ---------- | ------- | -------- | ---------------------------------------------------------------------------- | --------------------------- |
+| adsManager | null    | true     | `const adsManager = new NativeAdsManager(placementId, numberOfAdsToRequest)` | The ad manager to work with |
 
 ```js
 class MainApp extends React.Component {
@@ -226,9 +234,10 @@ class MainApp extends React.Component {
 
 ### BannerView
 
-BannerView is a component that allows you to display native banners (know as *AdView*).
+BannerView is a component that allows you to display native banners (know as _AdView_).
 
 Banners are available in 3 sizes:
+
 - `standard` (BANNER_HEIGHT_50)
 - `large` (BANNER_HEIGHT_90)
 - `rectangle` (RECTANGLE_HEIGHT_250)
@@ -251,7 +260,7 @@ function ViewWithBanner(props) {
         placementId="YOUR_BANNER_PLACEMENT_ID"
         type="standard"
         onPress={() => console.log('click')}
-        onError={(err) => console.log('error', err)}
+        onError={err => console.log('error', err)}
       />
     </View>
   );
@@ -304,7 +313,8 @@ InterstitialAdManager.showAd('placementId')
 Promise will be rejected when there's an error loading ads from Facebook Audience network. It will resolve with a
 `boolean` indicating whether user didClick an ad or not.
 
-On Android you have to add following activity to *AndroidManifest.xml*
+On Android you have to add following activity to _AndroidManifest.xml_
+
 ```xml
 <activity
   android:name="com.facebook.ads.InterstitialAdActivity"
@@ -316,7 +326,7 @@ On Android you have to add following activity to *AndroidManifest.xml*
 ### RewardedVideoAdManager
 
 ```js
-import { RewardedVideoAdManager } from "react-native-fbads";
+import { RewardedVideoAdManager } from 'react-native-fbads';
 ```
 
 RewardedVideoAdManager is a manager that allows you to load a rewarded video, then show the video once the video is loaded, in that order.
@@ -381,7 +391,9 @@ AdSettings.clearTestDevices();
 Sets current SDK log level.
 
 ```js
-AdSettings.setLogLevel('none' | 'debug' | 'verbose' | 'warning' | 'error' | 'notification');
+AdSettings.setLogLevel(
+  'none' | 'debug' | 'verbose' | 'warning' | 'error' | 'notification'
+);
 ```
 
 **Note:** This method is a noop on Android.
@@ -443,6 +455,7 @@ $ cd ./example && npm run android
 Some of the API explanations were borrowed from Facebook SDK documentation.
 
 <!-- badges -->
+
 [version-badge]: https://img.shields.io/npm/v/react-native-fbads.svg?style=flat-square
 [package]: https://www.npmjs.com/package/react-native-fbads
 [chat-badge]: https://img.shields.io/discord/426714625279524876.svg?style=flat-square&colorB=758ED3

--- a/README.md
+++ b/README.md
@@ -183,12 +183,29 @@ class AdComponent extends React.Component {
 export default withNativeAd(AdComponent);
 ```
 
+#### 4. Displaying Facebook Ad Choices Icon
+Facebook's guidelines require every native ad to include the Ad Choices component, which contains a small clickable icon.
+
+Example usage:
+```js
+import { AdChoices } from 'react-native-fbads'
+
+...
+
+<AdChoices style={{position:'absolute', left:0, top:0}}/>
+```
+| prop | default | required  | description |
+|------|---------|-----------|-------------|
+| style | undefined | false | Standard Style prop |
+| expandable | false | false | (iOS only) makes the native AdChoices expandable |
+
+
 #### 3. Rendering an ad
 
 Finally, you can render your wrapped component from previous step and pass it `adsManager`
 of your choice.
 
-##### Adchoice position props
+##### Native Ad Props
 
 | prop | default | required | params | description |
 |------------------|----------|----------|-----------------------------------------------------------------------------|----------------------------------|
@@ -199,7 +216,7 @@ class MainApp extends React.Component {
   render() {
     return (
       <View>
-        <AdComponent adsManager={adsManager} adChoicePosition="topLeft" expandable={false} />
+        <AdComponent adsManager={adsManager} />
       </View>
     );
   }

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ import { AdChoices } from 'react-native-fbads'
 |------|---------|-----------|-------------|
 | style | undefined | false | Standard Style prop |
 | expandable | false | false | (iOS only) makes the native AdChoices expandable |
+| location | topLeft | false | (iOS only) controls the location of the AdChoices icon
 
 
 #### 3. Rendering an ad

--- a/README.md
+++ b/README.md
@@ -188,11 +188,11 @@ Facebook's guidelines require every native ad to include the Ad Choices componen
 
 Example usage:
 ```js
-import { AdChoices } from 'react-native-fbads'
+import { AdChoicesView } from 'react-native-fbads'
 
 ...
 
-<AdChoices style={{position:'absolute', left:0, top:0}}/>
+<AdChoicesView style={{position:'absolute', left:0, top:0}}/>
 ```
 | prop | default | required  | description |
 |------|---------|-----------|-------------|

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ import { AdChoicesView } from 'react-native-fbads'
 ```
 
 #### Props
+
 | prop       | default   | required | description                                            |
 | ---------- | --------- | -------- | ------------------------------------------------------ |
 | style      | undefined | false    | Standard Style prop                                    |

--- a/README.md
+++ b/README.md
@@ -192,9 +192,7 @@ of your choice.
 
 | prop | default | required | params | description |
 |------------------|----------|----------|-----------------------------------------------------------------------------|----------------------------------|
-| adsManager | null | true | `const adsManager = new NativeAdsManager(placementId, numberOfAdsToRequest)` | Set Placement id for native ad |
-| adChoicePosition | topRight | false | `topLeft , topRight , bottomLeft , bottomRight` | Set Ad choice position |
-| expandable | true | false | BOOLEAN | IOS only set Adchoice expandable |
+| adsManager | null | true | `const adsManager = new NativeAdsManager(placementId, numberOfAdsToRequest)` | The ad manager to work with |
 
 ```js
 class MainApp extends React.Component {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
+    compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.facebook.android:audience-network-sdk:4.99.1'
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    compile "com.facebook.react:react-native:+"
     compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.facebook.android:audience-network-sdk:4.99.1'
 }

--- a/withNativeAd.js
+++ b/withNativeAd.js
@@ -53,7 +53,7 @@ type RegisterableContextValueType = {
 export type TriggerableContextValueType = MultipleRegisterablesContextValueType;
 export type AdIconViewContextValueType = RegisterableContextValueType;
 export type MediaViewContextValueType = RegisterableContextValueType;
-export type AdChoicesViewContextValueType = string | null;
+export type AdChoicesViewContextValueType = string;
 /**
  * Higher order function that wraps given `Component` and provides `nativeAd` as a prop
  *
@@ -66,7 +66,7 @@ const defaultValue = { register: null, unregister: null };
 export const TriggerableContext = React.createContext(defaultValue);
 export const MediaViewContext = React.createContext(defaultValue);
 export const AdIconViewContext = React.createContext(defaultValue);
-export const AdChoicesViewContext = React.createContext(null);
+export const AdChoicesViewContext = React.createContext();
 
 export default <T>(Component: React.ComponentType<T>) =>
   class NativeAdWrapper extends React.Component<

--- a/withNativeAd.js
+++ b/withNativeAd.js
@@ -53,7 +53,7 @@ type RegisterableContextValueType = {
 export type TriggerableContextValueType = MultipleRegisterablesContextValueType;
 export type AdIconViewContextValueType = RegisterableContextValueType;
 export type MediaViewContextValueType = RegisterableContextValueType;
-
+export type AdChoicesViewContextValueType = string | null;
 /**
  * Higher order function that wraps given `Component` and provides `nativeAd` as a prop
  *
@@ -66,6 +66,7 @@ const defaultValue = { register: null, unregister: null };
 export const TriggerableContext = React.createContext(defaultValue);
 export const MediaViewContext = React.createContext(defaultValue);
 export const AdIconViewContext = React.createContext(defaultValue);
+export const AdChoicesViewContext = React.createContext(null);
 
 export default <T>(Component: React.ComponentType<T>) =>
   class NativeAdWrapper extends React.Component<
@@ -208,17 +209,21 @@ export default <T>(Component: React.ComponentType<T>) =>
               <TriggerableContext.Provider
                 value={this._registerFunctionsForTriggerables}
               >
-                {/* In case of no AdIconView or MediaView in Custom layout,
+                <AdChoicesViewContext.Provider
+                  value={this.props.adsManager.toJSON()}
+                >
+                  {/* In case of no AdIconView or MediaView in Custom layout,
                                      It will keep Triggerable component Functional */}
-                <AdIconView
-                  nativeAd={this.state.ad}
-                  style={{ width: 0, height: 0 }}
-                />
-                <MediaView
-                  nativeAd={this.state.ad}
-                  style={{ width: 0, height: 0 }}
-                />
-                <Component {...componentProps} nativeAd={this.state.ad} />
+                  <AdIconView
+                    nativeAd={this.state.ad}
+                    style={{ width: 0, height: 0 }}
+                  />
+                  <MediaView
+                    nativeAd={this.state.ad}
+                    style={{ width: 0, height: 0 }}
+                  />
+                  <Component {...componentProps} nativeAd={this.state.ad} />
+                </AdChoicesViewContext.Provider>
               </TriggerableContext.Provider>
             </MediaViewContext.Provider>
           </AdIconViewContext.Provider>

--- a/withNativeAd.js
+++ b/withNativeAd.js
@@ -11,7 +11,7 @@ import {
 import AdsManager from './NativeAdsManager';
 import { NativeAdIconView } from './AdIconViewManager';
 import { NativeMediaView } from './MediaViewManager';
-import { MediaView, AdIconView, AdChoicesView } from './index';
+import { MediaView, AdIconView } from './index';
 
 const NativeAdView = requireNativeComponent('CTKNativeAd', null);
 

--- a/withNativeAd.js
+++ b/withNativeAd.js
@@ -37,9 +37,7 @@ type NativeAdWrapperState = {
 
 type NativeAdWrapperProps = {
   adsManager: AdsManager,
-  onAdLoaded?: ?(?NativeAd) => void,
-  adChoicePosition?: ?string,
-  expandable?: ?boolean
+  onAdLoaded?: ?(?NativeAd) => void
 };
 
 type MultipleRegisterablesContextValueType = {
@@ -198,7 +196,7 @@ export default <T>(Component: React.ComponentType<T>) =>
     };
 
     renderAdComponent(componentProps: T) {
-      const { adsManager, adChoicePosition, expandable } = this.props;
+      const { adsManager } = this.props;
       if (this.state.ad) {
         return (
           <AdIconViewContext.Provider
@@ -221,11 +219,6 @@ export default <T>(Component: React.ComponentType<T>) =>
                   style={{ width: 0, height: 0 }}
                 />
                 <Component {...componentProps} nativeAd={this.state.ad} />
-                <AdChoicesView
-                  placementId={adsManager.toJSON()}
-                  expandable={expandable || true}
-                  position={adChoicePosition}
-                />
               </TriggerableContext.Provider>
             </MediaViewContext.Provider>
           </AdIconViewContext.Provider>


### PR DESCRIPTION
In order to provide fine grained control over the native ad layout, this PR removes `AdChoicesView` from the `withNativeAd.js` wrapper and lets the user layout the component to his liking.

The `placementId` prop in `AdChoicesView` was replaced with a Context consumer similar to how `MediaView`, `AdIconView` and `TriggerableView` work, so users don't need to pass anything manually.

This PR contains the following **breaking changes**:
- The default ad layout no longer contains the Ad Choices icon.
- Ad choices related props were removed from `withNativeAd`. Users should remove the `expandable` and `adChoicesStyle` props. Documentation updated accordingly.
- AdChoicesView `position` prop was replaced with the standard `style` prop.
- To control the native position of the AdChoices icon, use the `location` prop.
