### PR TITLE
Fix Invalid View Registration Handles

### DIFF
--- a/src/util/areSetsEqual.ts
+++ b/src/util/areSetsEqual.ts
@@ -1,0 +1,7 @@
+export const areSetsEqual = <T>(a: Set<T>, b: Set<T>) => {
+  if (a.size !== b.size) return false;
+  for (const aItem of a) {
+    if (!b.has(aItem)) return false;
+  }
+  return true;
+};


### PR DESCRIPTION
**Please review #134 first as this PR relies on it.**

#### Short Background
When a native ad component updates, we have to register any views as intractable natively.
The logic that does that is the native ad wrapper's `componentDidUpdate`, which checks for node handle changes and performs the native update if required.

The current logic has some flaws:
- First, it may execute even if AdIconView or MediaView have invalid handles (`-1`), which will cause the native side to reject the registration with an `E_NO_VIEW_FOR_TAG` or `E_INVALID_VIEW_CLASS`. This causes an unhandled promise rejection inside the component.
- Second, it requires `clickableChildren` to not be empty, which shouldn't be a requirement (since MediaView and AdIconView may compose a native view on their own)

This PR addresses both flaws.
- We first ensure all required handles are present (both MediaView and AdIconView)
- We no longer check if `clickableChildren.size > 0` before registering.

Also the code has been slightly refactored to avoid spaghetti `if`s. Set comparison has been exported to it's own function (`areSetsEqual`)

I've tested the change on both iOS and Android and everything seems to be working correctly.
