### PR TITLE
Make Pod dependency recursive (incl. Patch for #163)

### DIFF
--- a/android/app/src/main/java/suraj/tiwari/reactnativefbads/NativeAdManager.java
+++ b/android/app/src/main/java/suraj/tiwari/reactnativefbads/NativeAdManager.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Locale;
 
 public class NativeAdManager extends ReactContextBaseJavaModule implements NativeAdsManager.Listener {
   /**

--- a/ios/ReactNativeAdsFacebook.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeAdsFacebook.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/**",
-					"$(SRCROOT)/../../../ios/Pods/FBAudienceNetwork",
+					"$(SRCROOT)/../../../ios/Pods/FBAudienceNetwork/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -324,7 +324,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/**",
-					"$(SRCROOT)/../../../ios/Pods/FBAudienceNetwork",
+					"$(SRCROOT)/../../../ios/Pods/FBAudienceNetwork/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## Summary
- It closes #163. I added the missing `import java.util.Locale;` for Android project. 
- It also resolves an ios compilation issue:
  - The actual framework file of Pod exists in `Static` folder which is one-level nested.
  - Making the fragment search path recursive resolves this issue.

<img width="540" alt="screen shot 2018-11-13 at 3 06 39 pm" src="https://user-images.githubusercontent.com/1323963/48394185-e715c480-e755-11e8-9a8f-785abff8f470.png">

- I setup FacebookAds from the scrath, and it worked well with this commit.