### PR TITLE
Fix doubleValue crash

### DIFF
--- a/src/native-ads/withNativeAd.tsx
+++ b/src/native-ads/withNativeAd.tsx
@@ -118,8 +118,14 @@ export default <T extends HasNativeAd>(
         adIconViewNodeHandleChanged ||
         clickableChildrenChanged
       ) {
+        const viewHandle = findNodeHandle(this.nativeAdViewRef!);
+        if (!viewHandle) {
+          // Skip registration if the view is no longer valid.
+          return;
+        }
+
         AdsManager.registerViewsForInteractionAsync(
-          findNodeHandle(this.nativeAdViewRef!)!,
+          viewHandle,
           this.state.mediaViewNodeHandle,
           this.state.adIconViewNodeHandle,
           [...this.state.clickableChildren]

--- a/src/native-ads/withNativeAd.tsx
+++ b/src/native-ads/withNativeAd.tsx
@@ -150,7 +150,12 @@ export default <T extends HasNativeAd>(
       this.setState({ adIconViewNodeHandle: -1 });
 
     private registerClickableChild = (child: ComponentOrClass) => {
-      const handle = findNodeHandle(child) || -1;
+      const handle = findNodeHandle(child);
+
+      if (!handle) {
+        return;
+      }
+
       this.clickableChildrenNodeHandles.set(child, handle);
 
       this.setState({


### PR DESCRIPTION
Attempts to fix the crash in https://github.com/callstack/react-native-fbads/issues/168#issuecomment-444436316

Root cause appears to be React Native attempting to unpack an array in a native call, but that array contains a null value which crashes the app. I believe that would be the `clickableChildren` array in `registerViewsForInteraction`.

I'm also experiencing this issue in production. This PR ensures we don't attempt to register null handles.