### PR TITLE
Added HOME/Documents/FacebookSDK as a Framework Path

### DIFF
--- a/ios/ReactNativeAdsFacebook.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeAdsFacebook.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/**",
 					"$(SRCROOT)/../../../ios/Pods/FBAudienceNetwork/**",
+					"$(HOME)/Documents/FacebookSDK/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/ReactNativeAdsFacebook.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeAdsFacebook.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/**",
 					"$(SRCROOT)/../../../ios/Pods/FBAudienceNetwork/**",
+					"$(HOME)/Documents/FacebookSDK/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

For those who don't install this package via CocoaPods, we need to specify a path where the framework _FBAudienceNetwork.framework_ is placed so that react-native-fbads can access it.

That's why I added the $(HOME)/Documents/FacebookSDK as a path for that framework, since all other Facebook related frameworks are placed.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
