### PR TITLE
CTKBannerView was not found in the UIManager (Solved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,20 @@ If you didn't use Cocoapods to integrate the Facebook SDK, you'll need to manual
 ```java
 
 import com.facebook.ads.AudienceNetworkAds; // <-- add this
+import suraj.tiwari.reactnativefbads.FBAdsPackage; // <-- add this
 
 public class MainApplication extends Application implements ReactApplication {
 ...
-@Override public void onCreate() {
+  @Override 
+  public void onCreate() {
     super.onCreate();
     AudienceNetworkAds.initialize(this); // <-- add this
+  }
+  @Override
+  protected List<ReactPackage> getPackages() {
+    return Arrays.<ReactPackage>asList(
+          new FBAdsPackage()   // <-- add this
+    );
   }
 ...
 }


### PR DESCRIPTION
CTKBannerView was not found in the UIManager issue will be solved by these imports

### Summary

CTKBannerView was not found in the UIManager was happening because of FBAdsPackage() has not been imported to MainApplication.