### PR TITLE
Added hook for onAdLoad for BannerView

### DIFF
--- a/android/app/src/main/java/suraj/tiwari/reactnativefbads/BannerView.java
+++ b/android/app/src/main/java/suraj/tiwari/reactnativefbads/BannerView.java
@@ -69,6 +69,8 @@ public class BannerView extends ReactViewGroup implements AdListener, LifecycleE
     myAdView.layout(0, 0, pxW, pxH);
 
     addView(myAdView);
+
+    mEventEmitter.receiveEvent(getId(), "onAdLoad", null);
   }
 
   @Override

--- a/android/app/src/main/java/suraj/tiwari/reactnativefbads/BannerViewManager.java
+++ b/android/app/src/main/java/suraj/tiwari/reactnativefbads/BannerViewManager.java
@@ -50,7 +50,9 @@ public class BannerViewManager extends SimpleViewManager<BannerView> {
       "onAdError",
       MapBuilder.of("registrationName", "onAdError"),
       "onLoggingImpression",
-      MapBuilder.of("registrationName", "onLoggingImpression")
+      MapBuilder.of("registrationName", "onLoggingImpression"),
+      "onAdLoad",
+      MapBuilder.of("registrationName", "onAdLoad")
     );
   }
 

--- a/ios/ReactNativeAdsFacebook/EXBannerView.h
+++ b/ios/ReactNativeAdsFacebook/EXBannerView.h
@@ -5,6 +5,7 @@
 
 @property (nonatomic, copy) RCTBubblingEventBlock onAdPress;
 @property (nonatomic, copy) RCTBubblingEventBlock onAdError;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdLoad;
 
 @property (nonatomic, strong) NSNumber *size;
 @property (nonatomic, strong) NSString *placementId;

--- a/ios/ReactNativeAdsFacebook/EXBannerView.m
+++ b/ios/ReactNativeAdsFacebook/EXBannerView.m
@@ -81,6 +81,16 @@
   }
 }
 
+- (void)adViewDidLoad:(FBAdView *)adView
+{
+  NSLog(@"Ad was loaded and ready to be displayed");
+
+  if (_onAdLoad) {
+    _onAdLoad(nil);
+  }
+}
+
+
 - (void)adViewDidFinishHandlingClick:(FBAdView *)adView {}
 - (void)adViewWillLogImpression:(FBAdView *)adView {}
 

--- a/ios/ReactNativeAdsFacebook/EXBannerViewManager.m
+++ b/ios/ReactNativeAdsFacebook/EXBannerViewManager.m
@@ -17,6 +17,7 @@ RCT_EXPORT_MODULE(CTKBannerViewManager)
 
 RCT_EXPORT_VIEW_PROPERTY(size, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(placementId, NSString)
+RCT_EXPORT_VIEW_PROPERTY(onAdLoad, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAdPress, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAdError, RCTBubblingEventBlock)
 

--- a/src/BannerViewManager.tsx
+++ b/src/BannerViewManager.tsx
@@ -7,6 +7,7 @@ interface NativeBannerViewProps {
   size: number;
   onAdPress: Function;
   onAdError: Function;
+  onAdLoad: Function;
   style: StyleProp<ViewStyle>;
   placementId: string;
 }
@@ -16,6 +17,7 @@ interface BannerViewProps {
   placementId: string;
   onPress: Function;
   onError: Function;
+  onLoad: Function;
   style: StyleProp<ViewStyle>;
 }
 
@@ -34,7 +36,7 @@ const getSizeForType = (type: AdType) => sizeForType[type];
 
 // tslint:disable-next-line:variable-name
 const BannerView = (props: BannerViewProps) => {
-  const { type, onPress, onError, style, ...restProps } = props;
+  const { type, onPress, onError, onLoad, style, ...restProps } = props;
   const size = getSizeForType(type);
 
   return (
@@ -42,6 +44,7 @@ const BannerView = (props: BannerViewProps) => {
       size={size}
       onAdPress={onPress}
       onAdError={onError}
+      onAdLoad={onLoad}
       style={[style, { height: size }]}
       {...restProps}
     />


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Added functionality to pass prop - onLoad into BannerView for iOS and Android

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### The Problem
There is no way to pass a callback to handle the 'adViewDidLoad' (iOS) and 'onAdLoaded' (Android) events for FB BannerView

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Add the onLoad prop (Function) into the <BannerView> component and see if the callback is executed when the ad has loaded. 
