### PR TITLE
Add Missing React Module Annotation CTKNativeAdManager

### DIFF
--- a/android/app/src/main/java/suraj/tiwari/reactnativefbads/NativeAdManager.java
+++ b/android/app/src/main/java/suraj/tiwari/reactnativefbads/NativeAdManager.java
@@ -16,6 +16,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
+import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.UIBlock;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Locale;
 
+@ReactModule(name = "CTKNativeAdManager")
 public class NativeAdManager extends ReactContextBaseJavaModule implements NativeAdsManager.Listener {
   /**
    * @{Map} with all registered fb ads managers


### PR DESCRIPTION
Fixs: https://github.com/callstack/react-native-fbads/issues/203

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Sometimes a Native Ad Unit will throw an error saying "Error while updating property 'adsManager' of a view managed by: CTKNativeAd".

This is due to missing React Module Annotation for CTKNativeAdManager in `react-native-fbads/android/app/src/main/java/suraj/tiwari/reactnativefbads/NativeAdManager.java`

### Test plan

Update checkout this pull and rebuild, it should fix the issue.
