### PR TITLE
library deprecation fix & minor fixes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile "com.android.support:recyclerview-v7:${safeExtGet('supportLibVersion', '26.1.0')}"
-    compile 'com.facebook.android:audience-network-sdk:5.1.0'
+    implementation 'com.facebook.react:react-native:+'
+    implementation "com.android.support:recyclerview-v7:${safeExtGet('supportLibVersion', '26.1.0')}"
+    implementation 'com.facebook.android:audience-network-sdk:5.+'
 }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,6 @@
     "tslint-config-prettier": "^1.15.0",
     "typescript": "^3.1.2"
   },
-  "rnpm": {
-    "android": {
-      "sourceDir": "android/app"
-    }
-  },
   "keywords": [
     "react-native",
     "facebook",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  project: {
+    ios: {},
+    android: {
+       "sourceDir": "android/app"
+    }
+  },
+};


### PR DESCRIPTION
Fixes sdk deprecation, now using version 5.+ 
added react-native.config.js due to deprecation of rnpm config,
not using implementation instead of compile. 