### PR TITLE
#192 fixed BannerView shows as thin line

### DIFF
--- a/ios/ReactNativeAdsFacebook/EXBannerView.m
+++ b/ios/ReactNativeAdsFacebook/EXBannerView.m
@@ -29,24 +29,25 @@
   if (!_placementId || !_size) {
     return;
   }
-  
+
   if (_adView) {
     [_adView removeFromSuperview];
   }
-  
+
   FBAdSize fbAdSize = [self fbAdSizeForHeight:_size];
-  
+
   FBAdView *adView = [[FBAdView alloc] initWithPlacementID:_placementId
                                                     adSize:fbAdSize
                                         rootViewController:RCTPresentedViewController()];
-  
+
   adView.frame = CGRectMake(0, 0, adView.bounds.size.width, adView.bounds.size.height);
+  adView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   adView.delegate = self;
-  
+
   [adView loadAd];
-  
+
   [self addSubview:adView];
-  
+
   _adView = adView;
 }
 


### PR DESCRIPTION
### Summary

This PR resolve this issue:
https://github.com/callstack/react-native-fbads/issues/192 [IOS] BannerView shows as thin line

### Test plan

Test `<BannerView />` on iOS. The banner will be see good and the thin line will disappear.

Before:
![image](https://user-images.githubusercontent.com/870365/69965963-04d9d700-14db-11ea-92e4-6f984328583f.png)

Now:
![image](https://user-images.githubusercontent.com/870365/69966270-a6f9bf00-14db-11ea-8e7e-904571dee589.png)
