### PR TITLE
Removed "AdChoiceManager requires main queue" warning

### DIFF
--- a/ios/ReactNativeAdsFacebook/AdChoiceManager.m
+++ b/ios/ReactNativeAdsFacebook/AdChoiceManager.m
@@ -37,6 +37,10 @@ RCT_EXPORT_MODULE(AdChoicesView)
     return [[AdChoiceView new] initWithBridge:_bridge];
 }
 
++ (BOOL) requiresMainQueueSetup {
+    return YES;
+}
+
 RCT_EXPORT_VIEW_PROPERTY(placementId,NSString);
 RCT_EXPORT_VIEW_PROPERTY(location,UIRectCorner);
 RCT_EXPORT_VIEW_PROPERTY(expandable,BOOL);


### PR DESCRIPTION
### Summary

Removed "AdChoiceManager requires main queue" warning:
![image](https://user-images.githubusercontent.com/870365/69970921-b29db380-14e4-11ea-86bc-f9e0f46f2a4a.png)


### Test plan

"AdChoiceManager requires main queue" warning not appear.