### PR TITLE
Add preload functionality to Interstitial Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ InterstitialAdManager.showAd(placementId)
 
 The `showAd` method returns a promise that will be resolves once the ad has been either dismissed or clicked by the user. The promise will reject if an error occurs before displaying the ad, such as a network error.
 
+If you want to preload the ad and show it later you can use this instead:
+
+```js
+import { InterstitialAdManager } from 'react-native-fbads';
+
+InterstitialAdManager.preloadAd(placementId)
+  .then(didClick => {})
+  .catch(error => {});
+
+// Will show it if already loaded, or wait for it to load and show it.
+InterstitialAdManager.showPreloadedAd(placementId)
+```
+
 ### Native Ads
 
 Native Ads allow you to create custom ad layouts that match your app. Before proceeding, please review [Facebook's documentation on Native Ads](https://developers.facebook.com/docs/audience-network/native-ads/) to get a better understanding of the requirements Native Ads impose.

--- a/ios/ReactNativeAdsFacebook/EXBannerView.m
+++ b/ios/ReactNativeAdsFacebook/EXBannerView.m
@@ -41,7 +41,7 @@
                                         rootViewController:RCTPresentedViewController()];
 
   adView.frame = CGRectMake(0, 0, adView.bounds.size.width, adView.bounds.size.height);
-  adView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+  // adView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   adView.delegate = self;
 
   [adView loadAd];

--- a/ios/ReactNativeAdsFacebook/EXInterstitialAdManager.m
+++ b/ios/ReactNativeAdsFacebook/EXInterstitialAdManager.m
@@ -88,10 +88,12 @@ RCT_EXPORT_METHOD(
   ) {
   // If already loaded, show it
   if(_didLoad) {
-    [_interstitialAd showAdFromRootViewController:RCTPresentedViewController()];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [_interstitialAd showAdFromRootViewController:RCTPresentedViewController()];
+    });
   } else {
     // If not make sure its shown asap
-      _showWhenLoaded = true;
+    _showWhenLoaded = true;
   }
   resolve(nil);
 }

--- a/ios/ReactNativeAdsFacebook/EXInterstitialAdManager.m
+++ b/ios/ReactNativeAdsFacebook/EXInterstitialAdManager.m
@@ -38,7 +38,7 @@ RCT_EXPORT_MODULE(CTKInterstitialAdManager)
 }
 
 RCT_EXPORT_METHOD(
-  showAd:(NSString *)placementId
+  loadAd:(NSString *)placementId
   resolver:(RCTPromiseResolveBlock)resolve
   rejecter:(RCTPromiseRejectBlock)reject
 )
@@ -59,11 +59,22 @@ RCT_EXPORT_METHOD(
 //  }];
 }
 
+RCT_EXPORT_METHOD(showAd:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+  // Do something
+    if(_didLoad) {
+        [_interstitialAd showAdFromRootViewController:RCTPresentedViewController()];
+    }
+    
+  resolve(nil);
+}
+
 #pragma mark - FBInterstitialAdDelegate
 
 - (void)interstitialAdDidLoad:(__unused FBInterstitialAd *)interstitialAd
 {
-  [_interstitialAd showAdFromRootViewController:RCTPresentedViewController()];
+  //[_interstitialAd showAdFromRootViewController:RCTPresentedViewController()];
+  _didLoad = true
 }
 
 - (void)interstitialAd:(FBInterstitialAd *)interstitialAd didFailWithError:(NSError *)error
@@ -112,6 +123,7 @@ RCT_EXPORT_METHOD(
   _interstitialAd = nil;
   _adViewController = nil;
   _didClick = false;
+  _didLoad = false;
 }
 
 @end

--- a/src/InterstitialAdManager.ts
+++ b/src/InterstitialAdManager.ts
@@ -8,5 +8,19 @@ export default {
    */
   showAd(placementId: string): Promise<boolean> {
     return CTKInterstitialAdManager.showAd(placementId);
+  },
+
+  /**
+   * Preloads an interstitial ad for a given placementId
+   */
+  preloadAd(placementId: string): Promise<boolean> {
+    return CTKInterstitialAdManager.preloadAd(placementId);
+  },
+
+  /**
+   * Shows an already preloaded Ad
+   */
+  showPreloadedAd(placementId: string): Promise<boolean> {
+    return CTKInterstitialAdManager.showPreloadedAd(placementId);
   }
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Today the Interstitial loads and then shows up.  But in time critical scenarios it is better for the UX if the ad already is ready and loaded once it should be shown. 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
