### PR TITLE
Remove pod version pinning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note that for iOS, it's [recommended you use Cocoapods](https://developers.faceb
 1. Add the following Pod to your Podfile:
 
 ```
-pod 'FBAudienceNetwork', '~> 5.1.0'
+pod 'FBAudienceNetwork'
 ```
 
 2. Run `pod install`

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,5 +27,5 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation "com.android.support:recyclerview-v7:${safeExtGet('supportLibVersion', '26.1.0')}"
-    implementation 'com.facebook.android:audience-network-sdk:5.+'
+    implementation 'com.facebook.android:audience-network-sdk:6.+'
 }


### PR DESCRIPTION
version 5.1.0 is no longer supported by facebook.

