### PR TITLE
fix: support for iOS 14+ with `setAdvertiserTrackingEnabled`; remove rectangle banner on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ if (trackingStatus === 'authorized' || trackingStatus === 'unavailable') {
 Enables or disables personalized ads tracking on iOS 14+. See Facebook docs on [Advertising Tracking Enabled For Audience Network](https://developers.facebook.com/docs/audience-network/guides/advertising-tracking-enabled)
 
 > Requires iOS 14. On Android and iOS versions below 14, this will always be no-op.
-> **Note**: FB won't display adds when this is not set to true.
+> **Important: FB won't display adds unless this is set to `true`.**
 
 ```js
 AdSettings.setAdvertiserTrackingEnabled(true);

--- a/README.md
+++ b/README.md
@@ -390,12 +390,12 @@ if (trackingStatus === 'authorized' || trackingStatus === 'unavailable') {
 }
 ```
 
-> Requires iOS 14. On Android and iOS versions below 14, this will always be no-op.
-> **Note**: FB won't display adds when this is not set to true.
-
 ### setAdvertiserTrackingEnabled
 
 Enables or disables personalized ads tracking on iOS 14+. See Facebook docs on [Advertising Tracking Enabled For Audience Network](https://developers.facebook.com/docs/audience-network/guides/advertising-tracking-enabled)
+
+> Requires iOS 14. On Android and iOS versions below 14, this will always be no-op.
+> **Note**: FB won't display adds when this is not set to true.
 
 ```js
 AdSettings.setAdvertiserTrackingEnabled(true);

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ if (trackingStatus === 'authorized' || trackingStatus === 'unavailable') {
 ```
 
 > Requires iOS 14. On Android and iOS versions below 14, this will always be no-op.
+> **Note**: FB won't display adds when this is not set to true.
 
 ### setAdvertiserTrackingEnabled
 

--- a/README.md
+++ b/README.md
@@ -384,8 +384,20 @@ Requests permission to track the user. Requires an [`NSUserTrackingUsageDescript
 
 ```js
 const trackingStatus = await AdSettings.requestTrackingPermission();
-if (trackingStatus === 'authorized' || trackingStatus === 'unavailable')
+if (trackingStatus === 'authorized' || trackingStatus === 'unavailable') {
   AdSettings.setAdvertiserIDCollectionEnabled(true);
+  AdSettings.setAdvertiserTrackingEnabled(true);
+}
+```
+
+> Requires iOS 14. On Android and iOS versions below 14, this will always be no-op.
+
+### setAdvertiserTrackingEnabled
+
+Enables or disables ads tracking. Since the iOS 14 API has been introduced you will need set this flag in order to inform Facebook whether you should receive personalized ads. ( See [Advertising Tracking Enabled For Audience Network](https://developers.facebook.com/docs/audience-network/guides/advertising-tracking-enabled))
+
+```js
+AdSettings.setAdvertiserTrackingEnabled(true);
 ```
 
 ### setAdvertiserIDCollectionEnabled

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Banners are available in 3 sizes:
 
 - `standard` (BANNER_HEIGHT_50)
 - `large` (BANNER_HEIGHT_90)
-- `rectangle` (RECTANGLE_HEIGHT_250)
+- `rectangle` (RECTANGLE_HEIGHT_250: (currently only for Android)
 
 ```js
 import { BannerView } from 'react-native-fbads';

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -463,7 +463,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/example/ios/example/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/example/ios/example/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,37 +2,52 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/example/ios/example/Info.plist
+++ b/example/ios/example/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string/>
+	<string></string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -53,6 +53,8 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Testing purposes</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>AntDesign.ttf</string>

--- a/example/src/BannerAds/index.js
+++ b/example/src/BannerAds/index.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {StyleSheet, View} from 'react-native';
+import {StyleSheet, View, Platform} from 'react-native';
 import {Container} from 'native-base';
 import {BannerView} from 'react-native-fbads';
 import {bannerAdPlacementId} from '../Variables';
@@ -24,14 +24,16 @@ export default class BannerAd extends Component {
             onError={(err) => console.log('error', err)}
           />
         </View>
-        <View style={styles.bannerContainer}>
-          <BannerView
-            placementId={bannerAdPlacementId}
-            type="rectangle"
-            onPress={() => console.log('click')}
-            onError={(err) => console.log('error', err)}
-          />
-        </View>
+        {Platform.OS !== 'ios' ? (
+          <View style={styles.bannerContainer}>
+            <BannerView
+              placementId={bannerAdPlacementId}
+              type="rectangle"
+              onPress={() => console.log('click')}
+              onError={(err) => console.log('error', err)}
+            />
+          </View>
+        ) : null}
       </Container>
     );
   }

--- a/example/src/NativeAds/index.js
+++ b/example/src/NativeAds/index.js
@@ -1,16 +1,9 @@
-import React, { Component } from 'react';
-import { NativeAdsManager, AdSettings } from 'react-native-fbads';
-import { Container } from 'native-base';
-import { nativeAdPlacementId } from '../Variables/index';
+import React, {Component} from 'react';
+import {NativeAdsManager, AdSettings} from 'react-native-fbads';
+import {Container} from 'native-base';
 import NativeAdView from './NativeAdView';
 
-AdSettings.clearTestDevices();
-AdSettings.setLogLevel('debug');
-AdSettings.addTestDevice(AdSettings.currentDeviceHash);
-
-const adsManager = new NativeAdsManager(nativeAdPlacementId);
-
-export default class NativeAd extends Component<Props> {
+export default class NativeAd extends Component {
   render() {
     return (
       <Container
@@ -18,9 +11,11 @@ export default class NativeAd extends Component<Props> {
           justifyContent: 'center',
           backgroundColor: '#fff',
           padding: 20,
-        }}
-      >
-        <NativeAdView adsManager={adsManager} adChoicePosition="bottomRight" />
+        }}>
+        <NativeAdView
+          adsManager={this.props.adsManager}
+          adChoicePosition="bottomRight"
+        />
       </Container>
     );
   }

--- a/example/src/NativeAds/index.js
+++ b/example/src/NativeAds/index.js
@@ -1,9 +1,13 @@
 import React, {Component} from 'react';
 import {NativeAdsManager, AdSettings} from 'react-native-fbads';
 import {Container} from 'native-base';
+import {nativeAdPlacementId} from '../Variables';
+
 import NativeAdView from './NativeAdView';
 
 export default class NativeAd extends Component {
+  adsManager = new NativeAdsManager(nativeAdPlacementId);
+
   render() {
     return (
       <Container
@@ -13,7 +17,7 @@ export default class NativeAd extends Component {
           padding: 20,
         }}>
         <NativeAdView
-          adsManager={this.props.adsManager}
+          adsManager={this.adsManager}
           adChoicePosition="bottomRight"
         />
       </Container>

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -14,6 +14,7 @@ export default class Main extends Component {
 
     if (requestedStatus === 'authorized' || requestedStatus === 'unavailable') {
       AdSettings.setAdvertiserIDCollectionEnabled(true);
+      // Both calls are not related to each other
       // FB won't deliver any ads if this is set to false or not called at all.
       AdSettings.setAdvertiserTrackingEnabled(true);
     }

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -2,14 +2,11 @@ import React, {Component} from 'react';
 import {StyleSheet, Dimensions, TouchableHighlight} from 'react-native';
 import {Container, Text} from 'native-base';
 import {Actions} from 'react-native-router-flux';
-import {AdSettings, NativeAdsManager} from 'react-native-fbads';
-
-import {nativeAdPlacementId} from './Variables';
+import {AdSettings} from 'react-native-fbads';
 
 const {width} = Dimensions.get('window');
 
 export default class Main extends Component {
-  adsManager = new NativeAdsManager(nativeAdPlacementId);
   async componentDidMount() {
     AdSettings.setLogLevel('debug');
     AdSettings.addTestDevice(AdSettings.currentDeviceHash);
@@ -17,12 +14,14 @@ export default class Main extends Component {
     const trackingStatus = await AdSettings.getTrackingStatus();
     if (trackingStatus === 'authorized' || trackingStatus === 'unavailable') {
       AdSettings.setAdvertiserIDCollectionEnabled(true);
+      AdSettings.setAdvertiserTrackingEnabled(true);
       return;
     }
-    console.log('here');
+
     const requestedStatus = await AdSettings.requestTrackingPermission();
     if (requestedStatus === 'authorized' || requestedStatus === 'unavailable') {
       AdSettings.setAdvertiserIDCollectionEnabled(true);
+      AdSettings.setAdvertiserTrackingEnabled(true);
     }
   }
 
@@ -35,7 +34,7 @@ export default class Main extends Component {
         <TouchableHighlight
           underlayColor="#b2bbbc"
           style={styles.button}
-          onPress={() => Actions.nativeAd({adsManager: this.adsManager})}>
+          onPress={() => Actions.nativeAd()}>
           <Text style={styles.buttonText}>Native Ad</Text>
         </TouchableHighlight>
         <TouchableHighlight

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -2,17 +2,40 @@ import React, {Component} from 'react';
 import {StyleSheet, Dimensions, TouchableHighlight} from 'react-native';
 import {Container, Text} from 'native-base';
 import {Actions} from 'react-native-router-flux';
+import {AdSettings, NativeAdsManager} from 'react-native-fbads';
+
+import {nativeAdPlacementId} from './Variables';
 
 const {width} = Dimensions.get('window');
 
 export default class Main extends Component {
+  adsManager = new NativeAdsManager(nativeAdPlacementId);
+  async componentDidMount() {
+    AdSettings.setLogLevel('debug');
+    AdSettings.addTestDevice(AdSettings.currentDeviceHash);
+
+    const trackingStatus = await AdSettings.getTrackingStatus();
+    if (trackingStatus === 'authorized' || trackingStatus === 'unavailable') {
+      AdSettings.setAdvertiserIDCollectionEnabled(true);
+      return;
+    }
+    console.log('here');
+    const requestedStatus = await AdSettings.requestTrackingPermission();
+    if (requestedStatus === 'authorized' || requestedStatus === 'unavailable') {
+      AdSettings.setAdvertiserIDCollectionEnabled(true);
+    }
+  }
+
+  componentWillUnmount() {
+    AdSettings.clearTestDevices();
+  }
   render() {
     return (
       <Container style={styles.container}>
         <TouchableHighlight
           underlayColor="#b2bbbc"
           style={styles.button}
-          onPress={() => Actions.nativeAd()}>
+          onPress={() => Actions.nativeAd({adsManager: this.adsManager})}>
           <Text style={styles.buttonText}>Native Ad</Text>
         </TouchableHighlight>
         <TouchableHighlight

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -10,17 +10,11 @@ export default class Main extends Component {
   async componentDidMount() {
     AdSettings.setLogLevel('debug');
     AdSettings.addTestDevice(AdSettings.currentDeviceHash);
-
-    const trackingStatus = await AdSettings.getTrackingStatus();
-    if (trackingStatus === 'authorized' || trackingStatus === 'unavailable') {
-      AdSettings.setAdvertiserIDCollectionEnabled(true);
-      AdSettings.setAdvertiserTrackingEnabled(true);
-      return;
-    }
-
     const requestedStatus = await AdSettings.requestTrackingPermission();
+
     if (requestedStatus === 'authorized' || requestedStatus === 'unavailable') {
       AdSettings.setAdvertiserIDCollectionEnabled(true);
+      // FB won't deliver any ads if this is set to false or not called at all.
       AdSettings.setAdvertiserTrackingEnabled(true);
     }
   }

--- a/ios/ReactNativeAdsFacebook/EXAdSettingsManager.m
+++ b/ios/ReactNativeAdsFacebook/EXAdSettingsManager.m
@@ -130,6 +130,12 @@ RCT_EXPORT_METHOD(setAdvertiserIDCollectionEnabled:(BOOL)enabled)
 }
 
 
+RCT_EXPORT_METHOD(setAdvertiserTrackingEnabled:(BOOL)enabled)
+{
+    [FBAdSettings setAdvertiserTrackingEnabled:enabled];
+}
+
+
 - (void)bridgeDidForeground:(NSNotification *)notification
 {
   [FBAdSettings setMixedAudience:_isChildDirected];

--- a/src/AdSettings.ts
+++ b/src/AdSettings.ts
@@ -10,7 +10,12 @@ type SDKLogLevel =
   | 'error'
   | 'notification';
 
-export type TrackingStatus = 'unavailable' | 'denied' | 'authorized' | 'restricted' | 'not-determined';
+export type TrackingStatus =
+  | 'unavailable'
+  | 'denied'
+  | 'authorized'
+  | 'restricted'
+  | 'not-determined';
 
 export default {
   /**
@@ -83,5 +88,15 @@ export default {
    */
   setAdvertiserIDCollectionEnabled(enabled: boolean): void {
     CTKAdSettingsManager.setAdvertiserIDCollectionEnabled(enabled);
-  }
+  },
+
+  /**
+   * Enable or disable ads tracking. Only works for iOS 14+. In order to ask user for tracking permission (@see `requestTrackingPermission()`).
+   */
+  setAdvertiserTrackingEnabled(enabled: boolean): void {
+    if (Platform.OS !== 'ios') {
+      return;
+    }
+    CTKAdSettingsManager.setAdvertiserTrackingEnabled(enabled);
+  },
 };


### PR DESCRIPTION
### Summary
In this PR:
- [x] removed rectangle banner on ios
- [x] added support for ios 14+ by implementing `setAdvertiserTrackingEnabled` method
- [x] added readme for `setAdvertiserTrackingEnabled` method
### Test plan

1. Open iOS simulator/device with ios 14+
2. Give app tracking permission
3. Check all types of ads -> they should be visible