### PR TITLE
fix: Removed rectangle banner support; updated facebook android SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Follow the instructions on [react-native-fbsdk](https://github.com/facebook/reac
 
 ### Get a Placement ID
 
-Follow [Facebook's instructions](https://www.facebook.com/help/publisher/1195459597167215) to create placement IDs for your ads.
+Follow [Facebook's instructions](https://www.facebook.com/help/publisher/1195459597167215) to create placement IDs for your ads. In order to get test ads modify your placement ID as it shown [here](https://developers.facebook.com/docs/audience-network/guides/test/inserted-code).
 
 ### Add test devices and test users
 
@@ -237,11 +237,10 @@ class MainApp extends React.Component {
 
 BannerView is a component that allows you to display ads in a banner format (know as _AdView_).
 
-Banners are available in 3 sizes:
+Banners are available in 2 sizes:
 
 - `standard` (BANNER_HEIGHT_50)
 - `large` (BANNER_HEIGHT_90)
-- `rectangle` (RECTANGLE_HEIGHT_250) – currently Android only
 
 ```js
 import { BannerView } from 'react-native-fbads';

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,5 +28,5 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation "com.android.support:recyclerview-v7:${safeExtGet('supportLibVersion', '26.1.0')}"
     implementation 'com.facebook.android:audience-network-sdk:6.2.+'
-    implementation 'com.facebook.android:facebook-android-sdk:5.15.+'
+    implementation 'com.facebook.android:facebook-android-sdk:6.+'
 }

--- a/android/app/src/main/java/suraj/tiwari/reactnativefbads/BannerViewManager.java
+++ b/android/app/src/main/java/suraj/tiwari/reactnativefbads/BannerViewManager.java
@@ -24,9 +24,6 @@ public class BannerViewManager extends SimpleViewManager<BannerView> {
       case 90:
         adSize = AdSize.BANNER_HEIGHT_90;
         break;
-      case 250:
-        adSize = AdSize.RECTANGLE_HEIGHT_250;
-        break;
       case 50:
       default:
         adSize = AdSize.BANNER_HEIGHT_50;

--- a/example/src/BannerAds/index.js
+++ b/example/src/BannerAds/index.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {StyleSheet, View, Platform} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import {Container} from 'native-base';
 import {BannerView} from 'react-native-fbads';
 import {bannerAdPlacementId} from '../Variables';
@@ -24,16 +24,6 @@ export default class BannerAd extends Component {
             onError={(err) => console.log('error', err)}
           />
         </View>
-        {Platform.OS !== 'ios' ? (
-          <View style={styles.bannerContainer}>
-            <BannerView
-              placementId={bannerAdPlacementId}
-              type="rectangle"
-              onPress={() => console.log('click')}
-              onError={(err) => console.log('error', err)}
-            />
-          </View>
-        ) : null}
       </Container>
     );
   }

--- a/ios/ReactNativeAdsFacebook/EXBannerView.m
+++ b/ios/ReactNativeAdsFacebook/EXBannerView.m
@@ -56,8 +56,6 @@
   switch ([height intValue]) {
     case 90:
       return kFBAdSizeHeight90Banner;
-    case 250:
-      return kFBAdSizeHeight250Rectangle;
     case 50:
     default:
       return kFBAdSizeHeight50Banner;

--- a/src/BannerViewManager.tsx
+++ b/src/BannerViewManager.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { requireNativeComponent, StyleProp, ViewStyle } from 'react-native';
 
-type AdType = 'large' | 'rectangle' | 'standard';
+type AdType = 'large' | 'standard';
 
 interface NativeBannerViewProps {
   size: number;
@@ -28,8 +28,7 @@ const CTKBannerView = requireNativeComponent<NativeBannerViewProps>(
 
 const sizeForType: Record<AdType, number> = {
   large: 90,
-  rectangle: 250,
-  standard: 50
+  standard: 50,
 };
 
 const getSizeForType = (type: AdType) => sizeForType[type];


### PR DESCRIPTION
### Summary
We dropped rectangle size support because facebook sdk was returning `error 1001 "No fill"` for `rectangle` size -> therefore we couldn't display ad properly :(.
In this PR:
- [x] removed rectangle banner support and remaining parts on both platforms
- [x] updated readme about these changes
- [x] upgraded android facebook sdk to 6+ version

### Test plan
1. Open emulator / simulator(iOS) /device.
2. Navigate to Banner ads screen.
3. Two banners should be visible (standard, large).

