### PR TITLE
fix: include react-native.config.js in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "package.json",
     "yarn.lock",
     "dist",
+    "react-native.config.js",
     "ReactNativeAdsFacebook.podspec"
   ]
 }


### PR DESCRIPTION
### Summary
In this PR react-native.config.js has been added to the `files` in package.json because otherwise user that is using our package has to do it  anyway himself.