### PR TITLE
fix: autolinking fix with proper react-native config

### DIFF
--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,7 +1,3 @@
 rootProject.name = 'example'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
-include ':react-native-fbads'
-project(':react-native-fbads').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fbads/android/app')
-include ':react-native-fbsdk'
-project(':react-native-fbsdk').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fbsdk/android')
 include ':app'

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,8 +1,9 @@
 module.exports = {
-  project: {
-    ios: {},
-    android: {
-       "sourceDir": "android/app"
-    }
+  dependency: {
+    platforms: {
+      android: {
+        sourceDir: 'android/app',
+      },
+    },
   },
 };


### PR DESCRIPTION
### Summary
In this PR we fixed our react-native config. Thanks to that we were able to remove all react-native link remaining parts in example app in `settings.gradle` file.

### Test plan
Open example app :)
