### PR TITLE
chore: don't publish lock file to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "src",
     "LICENSE",
     "package.json",
-    "yarn.lock",
     "dist",
     "react-native.config.js",
     "ReactNativeAdsFacebook.podspec"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

yarn.lock doesn't need to be published to npm

### Test plan

None
