### PR TITLE
Updated AdChoiceView due crashing with UIRectCorner pointer

### DIFF
--- a/ios/ReactNativeAdsFacebook/AdChoiceView.h
+++ b/ios/ReactNativeAdsFacebook/AdChoiceView.h
@@ -14,7 +14,7 @@
 @interface AdChoiceView : RCTView
 
 @property (nonatomic, strong) NSString *placementId;
-@property (nonatomic) UIRectCorner *location;
+@property (nonatomic) UIRectCorner location;
 @property (nonatomic) BOOL *expandable;
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;

--- a/ios/ReactNativeAdsFacebook/AdChoiceView.m
+++ b/ios/ReactNativeAdsFacebook/AdChoiceView.m
@@ -30,7 +30,7 @@
     [self createViewIfCan:_placementId:_location: _expandable];
 }
 
-- (void)setLocation:(UIRectCorner *)location
+- (void)setLocation:(UIRectCorner)location
 {
     _location = location;
     [self createViewIfCan:_placementId:_location: _expandable];
@@ -42,7 +42,7 @@
     [self createViewIfCan:_placementId :_location :_expandable];
 }
 
-- (void)createViewIfCan:(NSString *)placementId :(UIRectCorner *) location :(BOOL) expandable
+- (void)createViewIfCan:(NSString *)placementId :(UIRectCorner) location :(BOOL) expandable
 {
     if (!location || !placementId) {
         return;
@@ -51,7 +51,7 @@
     FBNativeAdsManager *_adsManager = [nativeAdManager getFBAdsManager:placementId];
     FBNativeAd *nativeAd = [_adsManager nextNativeAd];
     FBAdChoicesView *adChoicesView = [[FBAdChoicesView alloc] initWithNativeAd:nativeAd expandable:expandable];
-    [adChoicesView updateFrameFromSuperview:*location];
+    [adChoicesView updateFrameFromSuperview:location];
     [self addSubview:adChoicesView];
 }
 


### PR DESCRIPTION
The crash occurred by a dereference location UIRectCorner and pass it through ```[adChoicesView updateFrameFromSuperview:*location];```.  If I remove the pointer from the location variable and it seems to work all fine and update the location it self on the AdChoiceView class.

I don't have that much experience with Objective-C it self, maybe someone could take a look at this and explain if this is a 'solid' fix or not, and make some improvements on the pull request.

### Summary

This pull request will fix the following issue #286 

